### PR TITLE
Update the DRA driver tag for GKE

### DIFF
--- a/demo/clusters/gke/install-dra-driver-gpu.sh
+++ b/demo/clusters/gke/install-dra-driver-gpu.sh
@@ -27,7 +27,7 @@ DRIVER_NAME=$(from_versions_mk "DRIVER_NAME")
 
 : ${IMAGE_REGISTRY:=ghcr.io/nvidia}
 : ${IMAGE_NAME:=${DRIVER_NAME}}
-: ${IMAGE_TAG:=6c34f5fb-ubi8}
+: ${IMAGE_TAG:=d1fad7ed-ubi9}
 
 helm upgrade -i --create-namespace --namespace nvidia nvidia-dra-driver-gpu ${PROJECT_DIR}/deployments/helm/nvidia-dra-driver-gpu \
   --set image.repository=${IMAGE_REGISTRY}/${IMAGE_NAME} \


### PR DESCRIPTION
This PR updates the DRA driver’s image tag to a newer version in the GKE installation script.