### PR TITLE
[no-relnote] remove unnecesary input on ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,4 +31,3 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.basic.outputs.version }}
-      build_multi_arch_images: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release-') }}


### PR DESCRIPTION
This patch removes the `build_multi_arch_images` input var at `ci.yaml` when calling the `image` workflow, as we have removed that input requirement in favor of always building multiarch images