### PR TITLE
[no-relnote] Add script to autogenerate Helm charts

### DIFF
--- a/hack/package-helm-charts.sh
+++ b/hack/package-helm-charts.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o pipefail
+
+# if arg1 is set, it will be used as the version number
+if [ -z "$1" ]; then
+  VERSION=$(awk -F= '/^VERSION/ { print $2 }' versions.mk | tr -d '[:space:]')
+else
+  VERSION=$1
+fi
+VERSION=${VERSION}
+
+# Create release assets to be uploaded
+helm package deployments/helm/nvidia-dra-driver-gpu/ --version $VERSION --app-version $VERSION


### PR DESCRIPTION
This patch introduces a new file `hack/package-helm-charts.sh` which is a helper script to build the helm chart for the `nvidia-dra-driver-gpu` repo

once a release is cut and images are published, this script eases the creation of a Helm Chart bundle
```bash
./hack/package-helm-charts.sh
```

This would generate a file on the project ROOT_DIR similar to `nvidia-dra-driver-gpu-v25.3.0.tgz` for version `v25.3.0` for example