### PR TITLE
Remove unnused setting in daemon claim config

### DIFF
--- a/api/nvidia.com/resource/v1beta1/computedomainconfig.go
+++ b/api/nvidia.com/resource/v1beta1/computedomainconfig.go
@@ -58,7 +58,6 @@ func (c *ComputeDomainChannelConfig) Validate() error {
 // ComputeDomainDaemonConfig holds the set of parameters for configuring an ComputeDomainDaemon.
 type ComputeDomainDaemonConfig struct {
 	metav1.TypeMeta `json:",inline"`
-	NumNodes        int    `json:"numNodes"`
 	DomainID        string `json:"domainID"`
 }
 
@@ -79,9 +78,6 @@ func (c *ComputeDomainDaemonConfig) Normalize() error {
 
 // Validate ensures that ComputeDomainDaemonConfig has a valid set of values.
 func (c *ComputeDomainDaemonConfig) Validate() error {
-	if c.NumNodes <= 0 {
-		return fmt.Errorf("numNodes must be greater than or equal to 1")
-	}
 	if c.DomainID == "" {
 		return fmt.Errorf("domainID cannot be empty")
 	}

--- a/cmd/compute-domain-controller/resourceclaimtemplate.go
+++ b/cmd/compute-domain-controller/resourceclaimtemplate.go
@@ -290,7 +290,6 @@ func (m *DaemonSetResourceClaimTemplateManager) Create(ctx context.Context, name
 	}
 
 	daemonConfig := nvapi.DefaultComputeDomainDaemonConfig()
-	daemonConfig.NumNodes = cd.Spec.NumNodes
 	daemonConfig.DomainID = string(cd.UID)
 
 	templateData := ResourceClaimTemplateTemplateData{

--- a/templates/compute-domain-daemon-claim-template.tmpl.yaml
+++ b/templates/compute-domain-daemon-claim-template.tmpl.yaml
@@ -22,5 +22,4 @@ spec:
           parameters:
             apiVersion: {{ .DaemonConfig.APIVersion }}
             kind: {{ .DaemonConfig.Kind }}
-            numNodes: {{ .DaemonConfig.NumNodes }}
             domainID: {{ .DaemonConfig.DomainID }}


### PR DESCRIPTION
The compute domain Daemon no longer needs to store it's own reference to the `NumNodes` in the compute domain. The `NumNodes` field of the domain itself is queried via the compute domain ID.