### PR TITLE
Set version to 25.3.0-rc.1

### DIFF
--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -27,6 +27,10 @@ ifeq ($(IMAGE_NAME),)
 IMAGE_NAME := $(REGISTRY)/$(DRIVER_NAME)
 endif
 
+# Note: this is sometimes a v-prefixed version string
+# (in case of proper releases) or sometimes a commit hash
+# (in case of regular CI builds) in which case VERSION
+# is not v-prefixed.
 IMAGE_VERSION := $(VERSION)
 
 IMAGE_TAG ?= $(IMAGE_VERSION)-$(DIST)

--- a/deployments/helm/nvidia-dra-driver-gpu/Chart.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/Chart.yaml
@@ -15,10 +15,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v25.3.0
+
+# Note(JP): no v prefix allowed
+version: 25.3.0-rc.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v25.3.0"
+
+# Note(JP): this currently defines the default `tag` value in a k8s
+# image specification, and therefore must currently be v-prefixed.
+appVersion: "v25.3.0-rc.1"

--- a/deployments/helm/nvidia-dra-driver-gpu/values.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/values.yaml
@@ -39,7 +39,9 @@ imagePullSecrets: []
 image:
   repository: nvcr.io/nvidia/cloud-native/k8s-dra-driver-gpu
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # Note: an empty string is translated to the `appVersion` string from
+  # the Helm chart YAML (effectively implementing the default value to be
+  # the current version).
   tag: ""
 
 serviceAccount:

--- a/hack/package-helm-charts.sh
+++ b/hack/package-helm-charts.sh
@@ -19,10 +19,19 @@ set -o pipefail
 # if arg1 is set, it will be used as the version number
 if [ -z "$1" ]; then
   VERSION=$(awk -F= '/^VERSION/ { print $2 }' versions.mk | tr -d '[:space:]')
+  # Remove any v prefix, if exists.
+  VERSION="${VERSION#v}"
 else
   VERSION=$1
 fi
 VERSION=${VERSION}
+
+
+# Note(JP): the goal below is for VERSION to always be
+# strictly semver-compliant (parseable with a semver
+# parser). That enables best compatibility with the Helm
+# ecosystem. For example, that means that no `v` prefix
+# should be used here.
 
 # Create release assets to be uploaded
 helm package deployments/helm/nvidia-dra-driver-gpu/ --version $VERSION --app-version $VERSION

--- a/versions.mk
+++ b/versions.mk
@@ -18,7 +18,7 @@ MODULE := github.com/NVIDIA/$(DRIVER_NAME)
 
 REGISTRY ?= nvcr.io/nvidia/cloud-native
 
-VERSION  ?= v25.3.0
+VERSION  ?= v25.3.0-rc.1
 
 # vVERSION represents the version with a guaranteed v-prefix
 vVERSION := v$(VERSION:v%=%)


### PR DESCRIPTION
We decided that we want to make a release candidate for the upcoming release at first.

Note that as of https://helm.sh/docs/topics/charts/#the-chartyaml-file the `version` field in a Helm chart YAML is required to be semver-compliant, and a `v` prefix isn't allowed: https://semver.org/#is-v123-a-semantic-version.

For simplicity, we keep the `appVersion` field the same (although it doesn't have the same strict constraint).

Edit: no, give appVersion a "v" prefix again because it populates the default value for the image tag at https://github.com/NVIDIA/k8s-dra-driver-gpu/blob/8d34f977b7bdd7b7cad8c3fd0d53229b1676ca0f/deployments/helm/nvidia-dra-driver-gpu/values.yaml#L43.