### PR TITLE
Remove v prefix from appVersion

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/Chart.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/Chart.yaml
@@ -25,5 +25,5 @@ version: 25.3.0-rc.1
 # It is recommended to use it with quotes.
 
 # Note(JP): this currently defines the default `tag` value in a k8s
-# image specification, and therefore must currently be v-prefixed.
-appVersion: "v25.3.0-rc.1"
+# image specification. A "v" is prefixed in our template helpers to ensure consistency.
+appVersion: "25.3.0-rc.1"

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/_helpers.tpl
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/_helpers.tpl
@@ -80,7 +80,7 @@ Selector labels
 Full image name with tag
 */}}
 {{- define "nvidia-dra-driver-gpu.fullimage" -}}
-{{- $tag := printf "%s" .Chart.AppVersion }}
+{{- $tag := printf "v%s" .Chart.AppVersion }}
 {{- .Values.image.repository -}}:{{- .Values.image.tag | default $tag -}}
 {{- end }}
 

--- a/hack/package-helm-charts.sh
+++ b/hack/package-helm-charts.sh
@@ -19,12 +19,11 @@ set -o pipefail
 # if arg1 is set, it will be used as the version number
 if [ -z "$1" ]; then
   VERSION=$(awk -F= '/^VERSION/ { print $2 }' versions.mk | tr -d '[:space:]')
-  # Remove any v prefix, if exists.
-  VERSION="${VERSION#v}"
 else
   VERSION=$1
 fi
-VERSION=${VERSION}
+# Remove any v prefix, if exists.
+VERSION="${VERSION#v}"
 
 
 # Note(JP): the goal below is for VERSION to always be


### PR DESCRIPTION
This change removes the v prefix from the Helm chart appVersion. The prefix is prepended in the template helpers if required.

This aligns this project with other projects such as the device plugin.