### PR TITLE
Change DRA driver container image URL in Helm chart

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/values.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/values.yaml
@@ -37,11 +37,12 @@ allowDefaultNamespace: false
 
 imagePullSecrets: []
 image:
-  repository: nvcr.io/nvidia/cloud-native/k8s-dra-driver-gpu
+  repository: nvcr.io/nvidia/k8s-dra-driver-gpu
   pullPolicy: IfNotPresent
   # Note: an empty string is translated to the `appVersion` string from
   # the Helm chart YAML (effectively implementing the default value to be
-  # the current version).
+  # the current version). Also note that a "v" is prefixed to the
+  # `appVersion` value.
   tag: ""
 
 serviceAccount:


### PR DESCRIPTION
Currently, Helm charts contain a bad image URL.

The actual image location is as of today `nvcr.io/nvidia/k8s-dra-driver-gpu:<image-tag>` (this is where build pipelines push)