### PR TITLE
Fix /proc/devices parse logic for device Major number

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/nvlib.go
+++ b/cmd/compute-domain-kubelet-plugin/nvlib.go
@@ -236,31 +236,29 @@ func (l deviceLib) getDeviceMajor(name string) (int, error) {
 	foundCharDevices := false
 
 	for scanner.Scan() {
-		line := scanner.Text()
+		// remove any whitespace
+		line := strings.TrimSpace(scanner.Text())
 
 		// Ignore empty lines
 		if line == "" {
 			continue
 		}
 
-		// Check for any line with text followed by a colon (header)
-		if strings.Contains(line, ":") {
-			// Stop if we've already found the character devices section and reached another section
-			if foundCharDevices {
-				break
-			}
-			// Check if we entered the character devices section
-			if strings.HasSuffix(line, ":") && strings.HasPrefix(line, "Character") {
-				foundCharDevices = true
-			}
-			// Continue to the next line, regardless
+		// Detect start of Character devices section
+		if strings.HasPrefix(line, "Character") && strings.HasSuffix(line, ":") {
+			foundCharDevices = true
 			continue
 		}
 
-		// If we've passed the character devices section, check for nvidiaCapsImexChannelsDeviceName
+		// Stop searching if we've found character devices and now hit another section header
+		if foundCharDevices && strings.HasSuffix(line, ":") {
+			break
+		}
+
+		// If we're in the character devices section
 		if foundCharDevices {
 			parts := strings.Fields(line)
-			if len(parts) == 2 && parts[1] == name {
+			if len(parts) >= 2 && parts[1] == name {
 				return strconv.Atoi(parts[0])
 			}
 		}


### PR DESCRIPTION
This is to fix the parse logic of `/proc/devices` in case the Character device block has an entry like this with a colon `:` e.g `504 NVDA2004:00` in which case we assume we are in a different section and we return -1 

Debug test:
```
sudo docker run -v $(pwd)/getDeviceInfo.go:/getDeviceInfo.go golang go run /getDeviceInfo.go
line is 504 NVDA2004:00
major -1
 ```
 
 Test function with improved logic 
 ```
 package main

import (
	"bufio"
	"fmt"
	"os"
	"strconv"
	"strings"
)

const (
	procDevicesPath                  = "/proc/devices"
	procDriverNvidiaPath             = "/proc/driver/nvidia"
	nvidiaCapsDeviceName             = "nvidia-caps"
	nvidiaCapsImexChannelsDeviceName = "nvidia-caps-imex-channels"
	nvidiaCapFabricImexMgmtPath      = "/proc/driver/nvidia/capabilities/fabric-imex-mgmt"
)

type deviceLib struct{}

func (l deviceLib) getDeviceMajor(name string) (int, error) {
	file, err := os.Open(procDevicesPath)
	if err != nil {
		return -1, err
	}
	defer file.Close()

	scanner := bufio.NewScanner(file)
	foundCharDevices := false

	for scanner.Scan() {
		// remove any whitespace
		line := strings.TrimSpace(scanner.Text())

		// Ignore empty lines
		if line == "" {
			continue
		}

		// Detect start of Character devices section
		if strings.HasPrefix(line, "Character") && strings.HasSuffix(line, ":") {
			foundCharDevices = true
			continue
		}

		// Stop searching if we've found character devices and now hit another section header
		if foundCharDevices && strings.HasSuffix(line, ":") {
			break
		}

		// If we're in the character devices section
		if foundCharDevices {
			parts := strings.Fields(line)
			if len(parts) >= 2 && parts[1] == name {
				return strconv.Atoi(parts[0])
			}
		}
	}

	return -1, scanner.Err()

}

func main() {
	l := deviceLib{}
	major, err := l.getDeviceMajor(nvidiaCapsDeviceName)
	if err != nil {
		fmt.Errorf("error getting device major: %w", err)
	} else {
		fmt.Printf("major %v\n", major)
	}
}
```
sudo docker run -v /$(pwd)/getDeviceInfo.go:/getDeviceInfo.go golang go run /getDeviceInfo.go