### PR TITLE
Log IMEX nodes_config.cfg at daemon startup for debuggability

### DIFF
--- a/templates/compute-domain-daemon.tmpl.yaml
+++ b/templates/compute-domain-daemon.tmpl.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: apps/v1
-kind: Daemonset
+kind: DaemonSet
 metadata:
   namespace: {{ .Namespace }}
   generateName: {{ .GenerateName }}
@@ -36,6 +36,8 @@ spec:
             touch /etc/nvidia-imex-null
             tail -f /dev/null & wait
           fi
+          # Emit nodes config for facilitating debug.
+          echo -e "/etc/nvidia-imex/nodes_config.cfg:\n\n" && cat /etc/nvidia-imex/nodes_config.cfg
           /usr/bin/nvidia-imex -c /etc/nvidia-imex/config.cfg
           tail -n +1 -f /var/log/nvidia-imex.log & wait
         resources:


### PR DESCRIPTION
IMEX daemon startup may fail with

>  No matching network interface found for any IP addresses in the node configuration file /etc/nvidia-imex/nodes_config.cfg.

When seeing this in the log output one naturally wonders: what _are_ the IP addresses set in that file? We should answer that question in the log.

It might be too late to shell into the container to inspect that file there.

In the trade-off between debuggability and absolutely-minimal-log-volume I lean towards the former for a young piece of software.

This is so far untested.