### PR TITLE
Fix /proc/devices parsing regex

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/nvlib.go
+++ b/cmd/compute-domain-kubelet-plugin/nvlib.go
@@ -237,7 +237,9 @@ func (l deviceLib) getDeviceMajor(name string) (int, error) {
 		// Extract the number as capture group (the first and only group).
 		"(?s)Character devices:.*?" +
 			"([0-9]+) " + regexp.QuoteMeta(name) +
-			".*Block devices:",
+			// Require `name` to be newline-terminated (to not match on a device
+			// that has `name` as prefix).
+			"\n.*Block devices:",
 	)
 
 	data, err := os.ReadFile(procDevicesPath)


### PR DESCRIPTION
Once again, we created a file wrongly here:

```
$ ls -la /dev/nvidia-caps
total 0
drwxr-xr-x  2 root root       100 Mar 26 15:57 .
drwxr-xr-x 19 root root      5120 Mar 25 16:33 ..
cr--------  1 root root 511,    1 Mar 25 16:33 nvidia-cap1
cr--r--r--  1 root root 511,    2 Mar 25 16:33 nvidia-cap2
cr--------  1 root root 234, 4323 Mar 26 15:57 nvidia-cap4323
```

The `234` is unexpected because 
```
$ cat /proc/devices
Character devices:
...
234 nvidia-caps-imex-channels
...
511 nvidia-caps
```
We matched on the former, and should have taken the latter.

Updated the regular expression to account for newline-termination of the needle. Visualized, with the new test case:
![image](https://github.com/user-attachments/assets/a06333c3-7d95-4801-92a7-3c911ffd7e2f)
