### PR TITLE
ComputeDomain kubelet plugin: mount /dev:/dev

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
@@ -103,6 +103,9 @@ spec:
         - name: driver-root
           mountPath: /driver-root
           readOnly: true
+        # Pragmatic solution for host-managed drivers located not at /.
+        - name: host-dev
+          mountPath: /dev
       {{- end }}
       {{- if .Values.resources.gpus.enabled }}
       - name: gpus
@@ -172,6 +175,9 @@ spec:
       - name: driver-root
         hostPath:
           path: {{ .Values.nvidiaDriverRoot }}
+      - name: host-dev
+        hostPath:
+          path: /dev
       {{- with .Values.kubeletPlugin.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
This is a patch for host-provided drivers located not directly under `/`.

With a host-provided driver at for example `/home/kubernetes/...` we will [choose](https://github.com/NVIDIA/k8s-dra-driver-gpu/blob/50703b0bcf601c6448ba996aa5a79fff82daa1cf/cmd/compute-domain-kubelet-plugin/root.go#L76) an in-container `devRoot` of `/`, but any mutation underneath that does not apply to the host.

That may result in 
```
Warning  Failed     0s (x18 over 3m24s)  kubelet            \
Error: failed to create containerd container: CDI device injection failed: failed to inject devices: failed to stat CDI host device "/dev/nvidia-caps/nvidia-cap4323": no such file or directory
```

(where the kubelet plugin _did_ create that dev node, just visible only in its own container, and hot on the host)

With this patch, any in-container mutation of `/dev` will take effect on the host.

Testing:

- didn't break basic Luna workflows (non-IMEX)
- basic IMEX test green on a GB200 system