### PR TITLE
switch to cuda base image

### DIFF
--- a/templates/compute-domain-daemon.tmpl.yaml
+++ b/templates/compute-domain-daemon.tmpl.yaml
@@ -22,7 +22,7 @@ spec:
         {{ .ComputeDomainLabelKey }}: {{ .ComputeDomainLabelValue }}
       containers:
       - name: compute-domain-daemon
-        image: ubuntu:22.04
+        image: nvcr.io/nvidia/cuda:12.8.1-base-ubuntu22.04
         command: [sh, -c]
         args:
         - |-

--- a/templates/mps-control-daemon.tmpl.yaml
+++ b/templates/mps-control-daemon.tmpl.yaml
@@ -20,7 +20,7 @@ spec:
       hostPID: true
       containers:
       - name: mps-control-daemon
-        image: ubuntu:22.04
+        image: nvcr.io/nvidia/cuda:12.8.1-base-ubuntu22.04
         securityContext:
           privileged: true
         command: [chroot, /driver-root, sh, -c]


### PR DESCRIPTION
This PR is to make sure all the images are CUDA based images hosted on nvcr.io to meet with GPL and NVIDIA Open Source software requirement policies. The source code of all the components of CUDA based images are hosted on NVIDIA mirrors. By simply using the CUDA based images, we save us the effort of meeting with the compliance. Also, our images on nvcr.io are scanned and signed, so that adds a layer of security also. 

To add a bit more context, this issue was actually surfaced when a user was trying to run the imex channel example from internal docs. The compute-doamin daemonset responsible for creating the resourceclaims and setting up the imex channels was based on ubuntu22.04 from docker hub. As shown in the error below, Kubelet was ruuning into image pull errors due to docker rate limit issue without using an account.
```
Normal  Pulling  26m (x5 over 29m)   kubelet      Pulling image "ubuntu:22.04"
 Warning Failed   26m (x5 over 29m)   kubelet      Error: ErrImagePull
 Warning Failed   26m          kubelet      Failed to pull image "ubuntu:22.04": failed to pull and unpack image "docker.io/library/ubuntu:22.04": failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/ubuntu/manifests/sha256:23fdb0648173966ac0b863e5b3d63032e99f44533c5b396e62f29770ca2c5210: 429 Too Many Requests - Server message: toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
 Normal  BackOff  4m47s (x108 over 29m) kubelet      Back-off pulling image "ubuntu:22.04"
 Warning Failed   4m35s (x109 over 29m) kubelet      Error: ImagePullBackOff
 ```