### PR TITLE
Build with Go 1.23.8, update image metadata

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GOLANG_VERSION=1.23.1
+ARG GOLANG_VERSION=1.23.8
 # We use an ubuntu20.04 base image to allow for a more efficient multi-arch builds.
 FROM --platform=${BUILDOS}/amd64 nvcr.io/nvidia/cuda:12.8.0-base-ubuntu20.04 AS build
 
@@ -51,15 +51,15 @@ ENV NVIDIA_DRIVER_CAPABILITIES=utility
 ARG VERSION="N/A"
 ARG GIT_COMMIT="unknown"
 
-LABEL io.k8s.display-name="NVIDIA DRA Driver"
-LABEL name="NVIDIA DRA Driver"
+LABEL io.k8s.display-name="NVIDIA DRA Driver for GPUs"
+LABEL name="NVIDIA DRA Driver for GPUs"
 LABEL vendor="NVIDIA"
 LABEL version=${VERSION}
 LABEL com.nvidia.git-commit="${GIT_COMMIT}"
 LABEL release="N/A"
-LABEL summary="NVIDIA DRA driver for Kubernetes"
-LABEL description="See summary"
-LABEL org.opencontainers.image.description "NVIDIA GPU DRA driver for Kubernetes"
+LABEL summary="NVIDIA DRA Driver for GPUs"
+LABEL description="NVIDIA DRA Driver for GPUs"
+LABEL org.opencontainers.image.description "NVIDIA DRA Driver for GPUs"
 LABEL org.opencontainers.image.source "https://github.com/NVIDIA/k8s-dra-driver-gpu"
 
 RUN mkdir /licenses && mv /NGC-DL-CONTAINER-LICENSE /licenses/NGC-DL-CONTAINER-LICENSE

--- a/deployments/devel/Dockerfile
+++ b/deployments/devel/Dockerfile
@@ -14,7 +14,7 @@
 
 # This Dockerfile is also used to define the golang version used in this project
 # This allows dependabot to manage this version in addition to other images.
-FROM golang:1.23.1
+FROM golang:1.23.8
 
 WORKDIR /work
 COPY * .


### PR DESCRIPTION
Quick proposal for two unrelated and minor maintenance changes:

- Bump Golang from 1.23.1 to 1.23.8, see https://go.dev/doc/devel/release#go1.23.minor
- Streamline container image metadata (for us to hopefully slowly achieve convergence w.r.t. naming)

Note: we currently don't have a source of truth for the Go version, and need to update it in two places. `./hack/golang-version.sh` consults `deployments/devel/Dockerfile`.