### PR TITLE
Bump CUDA base image to version 12.8.1

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG GOLANG_VERSION=1.23.1
 # We use an ubuntu20.04 base image to allow for a more efficient multi-arch builds.
-FROM --platform=${BUILDOS}/amd64 nvcr.io/nvidia/cuda:12.8.0-base-ubuntu20.04 AS build
+FROM --platform=${BUILDOS}/amd64 nvcr.io/nvidia/cuda:12.8.1-base-ubuntu20.04 AS build
 
 RUN apt-get update && \
     apt-get install -y wget make git gcc-aarch64-linux-gnu gcc \
@@ -43,7 +43,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     fi && \
     make CC=${cc} GOARCH=${TARGETARCH} PREFIX=/artifacts cmds
 
-FROM nvcr.io/nvidia/cuda:12.8.0-base-ubi9
+FROM nvcr.io/nvidia/cuda:12.8.1-base-ubi9
 
 ENV NVIDIA_DISABLE_REQUIRE="true"
 ENV NVIDIA_VISIBLE_DEVICES=all


### PR DESCRIPTION
The 12.8.1 images have been available since March 13, 2025: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags

This change affects the kubelet plugin images (gpu, cd), and the controller image.

