### PR TITLE
Use explicit addr for IMEX daemon probe (issue #328)

### DIFF
--- a/templates/compute-domain-daemon.tmpl.yaml
+++ b/templates/compute-domain-daemon.tmpl.yaml
@@ -53,7 +53,7 @@ spec:
               if [ -f /etc/nvidia-imex-null ]; then
                 exit 0
               fi
-              test "$(nvidia-imex-ctl -q)" = "READY"
+              test "$(nvidia-imex-ctl -q -i 127.0.0.1 50005)" = "READY"
           initialDelaySeconds: 1
           periodSeconds: 1
         livenessProbe:
@@ -65,7 +65,7 @@ spec:
                 if [ -f /etc/nvidia-imex-null ]; then
                   exit 0
                 fi
-                test "$(nvidia-imex-ctl -q)" = "READY"
+                test "$(nvidia-imex-ctl -q -i 127.0.0.1 50005)" = "READY"
           initialDelaySeconds: 10
           periodSeconds: 5
       # Repel all node taints.


### PR DESCRIPTION
This patch explicitly defines the address to connect to the local IMEX daemon, to fix:
```
Startup probe failed: Query Status returned error code: 14 - failed to connect to all addresses; last error: UNKNOWN: ipv6:%5B::%5D:50005: Address family not supported by protocol
```
The error above likely is a result of non-ideal "where should I connect to?" logic in `nvidia-imex-ctl`.

See original report and discussion in https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/328.