### PR TITLE
Increase log verbosity of CD+GPU kubelet plugins

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
@@ -67,7 +67,7 @@ spec:
             sed -i 's/^ModifyDeviceFiles: 1$/ModifyDeviceFiles: 0/' root/gpu-params
             mount --bind root/gpu-params /proc/driver/nvidia/params
           fi
-          compute-domain-kubelet-plugin
+          compute-domain-kubelet-plugin -v 6
         resources:
           {{- toYaml .Values.kubeletPlugin.containers.computeDomains.resources | nindent 10 }}
         env:
@@ -125,7 +125,7 @@ spec:
             sed -i 's/^ModifyDeviceFiles: 1$/ModifyDeviceFiles: 0/' root/gpu-params
             mount --bind root/gpu-params /proc/driver/nvidia/params
           fi
-          gpu-kubelet-plugin
+          gpu-kubelet-plugin -v 6
         resources:
           {{- toYaml .Values.kubeletPlugin.containers.gpus.resources | nindent 10 }}
         env:


### PR DESCRIPTION
Currently, in normal mode of operation we only see this log msg during plugin startup:
```
$ kubectl logs -n nvidia-dra-driver-gpu   nvidia-dra-driver-gpu-kubelet-plugin-jd6fr
I0425 07:17:41.377958       1 device_state.go:70] using devRoot=/driver-root
```

We at times have questions during debugging: does / did the plugin do the right thing? During that time we want to have increased log verbosity, as we have in 
https://github.com/NVIDIA/k8s-dra-driver-gpu/blob/a532ca241e2a4e28d555504bcb7caee9ec5c1005/deployments/helm/nvidia-dra-driver-gpu/templates/controller.yaml#L54
