### PR TITLE
Replace `drapbv1.Device` in CD+GPU plugins

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -24,8 +24,8 @@ import (
 
 	resourceapi "k8s.io/api/resource/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/klog/v2"
-	drapbv1 "k8s.io/kubelet/pkg/apis/dra/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
 
@@ -128,7 +128,7 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 	return state, nil
 }
 
-func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceClaim) ([]*drapbv1.Device, error) {
+func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceClaim) ([]kubeletplugin.Device, error) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -254,8 +254,8 @@ func (s *DeviceState) prepareDevices(ctx context.Context, claim *resourceapi.Res
 				cdiDevices = append(cdiDevices, d)
 			}
 
-			device := &drapbv1.Device{
-				RequestNames: []string{result.Request},
+			device := kubeletplugin.Device{
+				Requests:     []string{result.Request},
 				PoolName:     result.Pool,
 				DeviceName:   result.Device,
 				CDIDeviceIDs: cdiDevices,
@@ -266,12 +266,12 @@ func (s *DeviceState) prepareDevices(ctx context.Context, claim *resourceapi.Res
 			case ComputeDomainChannelType:
 				preparedDevice.Channel = &PreparedComputeDomainChannel{
 					Info:   s.allocatable[result.Device].Channel,
-					Device: device,
+					Device: &device,
 				}
 			case ComputeDomainDaemonType:
 				preparedDevice.Daemon = &PreparedComputeDomainDaemon{
 					Info:   s.allocatable[result.Device].Daemon,
-					Device: device,
+					Device: &device,
 				}
 			}
 

--- a/cmd/compute-domain-kubelet-plugin/driver.go
+++ b/cmd/compute-domain-kubelet-plugin/driver.go
@@ -196,20 +196,8 @@ func (d *driver) nodePrepareResource(ctx context.Context, claim *resourceapi.Res
 		return isPermanentError(err), res
 	}
 
-	// TODO: change return type of state.Prepare()
-	var prepDevs []kubeletplugin.Device
-	for _, d := range devs {
-		device := kubeletplugin.Device{
-			Requests:     d.RequestNames,
-			PoolName:     d.PoolName,
-			DeviceName:   d.DeviceName,
-			CDIDeviceIDs: d.CDIDeviceIDs,
-		}
-		prepDevs = append(prepDevs, device)
-	}
-
-	klog.Infof("Returning newly prepared devices for claim '%v': %v", claim.UID, prepDevs)
-	return true, kubeletplugin.PrepareResult{Devices: prepDevs}
+	klog.Infof("Returning newly prepared devices for claim '%v': %v", claim.UID, devs)
+	return true, kubeletplugin.PrepareResult{Devices: devs}
 }
 
 func (d *driver) nodeUnprepareResource(ctx context.Context, claimRef kubeletplugin.NamespacedObject) (bool, error) {

--- a/cmd/compute-domain-kubelet-plugin/prepared.go
+++ b/cmd/compute-domain-kubelet-plugin/prepared.go
@@ -17,7 +17,7 @@
 package main
 
 import (
-	drapbv1 "k8s.io/kubelet/pkg/apis/dra/v1beta1"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 )
 
 type PreparedDeviceList []PreparedDevice
@@ -31,12 +31,12 @@ type PreparedDevice struct {
 
 type PreparedComputeDomainChannel struct {
 	Info   *ComputeDomainChannelInfo `json:"info"`
-	Device *drapbv1.Device           `json:"device"`
+	Device *kubeletplugin.Device     `json:"device"`
 }
 
 type PreparedComputeDomainDaemon struct {
 	Info   *ComputeDomainDaemonInfo `json:"info"`
-	Device *drapbv1.Device          `json:"device"`
+	Device *kubeletplugin.Device    `json:"device"`
 }
 
 type PreparedDeviceGroup struct {
@@ -94,22 +94,22 @@ func (l PreparedDeviceList) ComputeDomainDaemons() PreparedDeviceList {
 	return devices
 }
 
-func (d PreparedDevices) GetDevices() []*drapbv1.Device {
-	var devices []*drapbv1.Device
+func (d PreparedDevices) GetDevices() []kubeletplugin.Device {
+	var devices []kubeletplugin.Device
 	for _, group := range d {
 		devices = append(devices, group.GetDevices()...)
 	}
 	return devices
 }
 
-func (g *PreparedDeviceGroup) GetDevices() []*drapbv1.Device {
-	var devices []*drapbv1.Device
+func (g *PreparedDeviceGroup) GetDevices() []kubeletplugin.Device {
+	var devices []kubeletplugin.Device
 	for _, device := range g.Devices {
 		switch device.Type() {
 		case ComputeDomainChannelType:
-			devices = append(devices, device.Channel.Device)
+			devices = append(devices, *device.Channel.Device)
 		case ComputeDomainDaemonType:
-			devices = append(devices, device.Daemon.Device)
+			devices = append(devices, *device.Daemon.Device)
 		}
 	}
 	return devices

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -24,8 +24,8 @@ import (
 
 	resourceapi "k8s.io/api/resource/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/klog/v2"
-	drapbv1 "k8s.io/kubelet/pkg/apis/dra/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
 
@@ -125,7 +125,7 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 	return state, nil
 }
 
-func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceClaim) ([]*drapbv1.Device, error) {
+func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceClaim) ([]kubeletplugin.Device, error) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -301,8 +301,8 @@ func (s *DeviceState) prepareDevices(ctx context.Context, claim *resourceapi.Res
 				cdiDevices = append(cdiDevices, d)
 			}
 
-			device := &drapbv1.Device{
-				RequestNames: []string{result.Request},
+			device := &kubeletplugin.Device{
+				Requests:     []string{result.Request},
 				PoolName:     result.Pool,
 				DeviceName:   result.Device,
 				CDIDeviceIDs: cdiDevices,

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -120,19 +120,8 @@ func (d *driver) nodePrepareResource(ctx context.Context, claim *resourceapi.Res
 		}
 	}
 
-	var prepDevs []kubeletplugin.Device
-	for _, d := range devs {
-		device := kubeletplugin.Device{
-			Requests:     d.RequestNames,
-			PoolName:     d.PoolName,
-			DeviceName:   d.DeviceName,
-			CDIDeviceIDs: d.CDIDeviceIDs,
-		}
-		prepDevs = append(prepDevs, device)
-	}
-
-	klog.Infof("Returning newly prepared devices for claim '%v': %v", claim.UID, prepDevs)
-	return kubeletplugin.PrepareResult{Devices: prepDevs}
+	klog.Infof("Returning newly prepared devices for claim '%v': %v", claim.UID, devs)
+	return kubeletplugin.PrepareResult{Devices: devs}
 }
 
 func (d *driver) nodeUnprepareResource(ctx context.Context, claimNs kubeletplugin.NamespacedObject) error {

--- a/cmd/gpu-kubelet-plugin/prepared.go
+++ b/cmd/gpu-kubelet-plugin/prepared.go
@@ -19,7 +19,7 @@ package main
 import (
 	"slices"
 
-	drapbv1 "k8s.io/kubelet/pkg/apis/dra/v1beta1"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 )
 
 type PreparedDeviceList []PreparedDevice
@@ -32,13 +32,13 @@ type PreparedDevice struct {
 }
 
 type PreparedGpu struct {
-	Info   *GpuInfo        `json:"info"`
-	Device *drapbv1.Device `json:"device"`
+	Info   *GpuInfo              `json:"info"`
+	Device *kubeletplugin.Device `json:"device"`
 }
 
 type PreparedMigDevice struct {
-	Info   *MigDeviceInfo  `json:"info"`
-	Device *drapbv1.Device `json:"device"`
+	Info   *MigDeviceInfo        `json:"info"`
+	Device *kubeletplugin.Device `json:"device"`
 }
 
 type PreparedDeviceGroup struct {
@@ -96,22 +96,22 @@ func (l PreparedDeviceList) MigDevices() PreparedDeviceList {
 	return devices
 }
 
-func (d PreparedDevices) GetDevices() []*drapbv1.Device {
-	var devices []*drapbv1.Device
+func (d PreparedDevices) GetDevices() []kubeletplugin.Device {
+	var devices []kubeletplugin.Device
 	for _, group := range d {
 		devices = append(devices, group.GetDevices()...)
 	}
 	return devices
 }
 
-func (g *PreparedDeviceGroup) GetDevices() []*drapbv1.Device {
-	var devices []*drapbv1.Device
+func (g *PreparedDeviceGroup) GetDevices() []kubeletplugin.Device {
+	var devices []kubeletplugin.Device
 	for _, device := range g.Devices {
 		switch device.Type() {
 		case GpuDeviceType:
-			devices = append(devices, device.Gpu.Device)
+			devices = append(devices, *device.Gpu.Device)
 		case MigDeviceType:
-			devices = append(devices, device.Mig.Device)
+			devices = append(devices, *device.Mig.Device)
 		}
 	}
 	return devices

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	k8s.io/component-base v0.33.0
 	k8s.io/dynamic-resource-allocation v0.33.0
 	k8s.io/klog/v2 v2.130.1
-	k8s.io/kubelet v0.33.0
 	k8s.io/kubernetes v1.33.0
 	k8s.io/mount-utils v0.33.0
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
@@ -85,6 +84,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
+	k8s.io/kubelet v0.33.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect


### PR DESCRIPTION
Code simplification without changing behavior. This replaces usage of `drapbv1.Device` with `kubeletplugin.Device`. Context: https://github.com/NVIDIA/k8s-dra-driver-gpu/pull/332#discussion_r2068196190