### PR TITLE
Remove needless arg from container/Dockerfile

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GOLANG_VERSION=1.24.2
 # We use an ubuntu20.04 base image to allow for a more efficient multi-arch builds.
 FROM  nvcr.io/nvidia/cuda:12.8.1-base-ubuntu20.04 AS build
 
@@ -21,6 +20,7 @@ RUN apt-get update && \
     && \
     rm -rf /var/lib/apt/lists/*
 
+# Require build arg.
 ARG GOLANG_VERSION=x.x.x
 
 RUN set -eux; \
@@ -35,8 +35,8 @@ RUN set -eux; \
     wget -nv -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
     | tar -C /usr/local -xz
 
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
 
 WORKDIR /build
 COPY . .


### PR DESCRIPTION
This change removes a (by now) superfluous arg. The removal simplifies dependabot-automated Golang bumps.

Note that GOLANG_VERSION is injected (based on the current source of truth) when invoking for example `make -f deployments/container/Makefile build`.

Connecting dots: https://github.com/NVIDIA/k8s-dra-driver-gpu/pull/324#discussion_r2056004549