### PR TITLE
Configure DRA lib to send (un)prepare calls concurrently

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/driver.go
+++ b/cmd/compute-domain-kubelet-plugin/driver.go
@@ -70,6 +70,13 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		kubeletplugin.KubeClient(driver.client),
 		kubeletplugin.NodeName(config.flags.nodeName),
 		kubeletplugin.DriverName(DriverName),
+		// By default, the DRA library serializes (un)prepare calls. That is, at
+		// most one such call is exposed to the driver at any given time.
+		// Disable that behavior: this driver has codependent prepare() actions
+		// (where for the first prepare() to eventually complete, a second
+		// prepare() must be incoming). Concurrency management for incoming
+		// requests is done with this driver's work queue abstraction.
+		kubeletplugin.Serialize(false),
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -52,6 +52,7 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		kubeletplugin.KubeClient(driver.client),
 		kubeletplugin.NodeName(config.flags.nodeName),
 		kubeletplugin.DriverName(DriverName),
+		kubeletplugin.Serialize(false),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We noticed slowness of ComputeDomain-consuming workload being scheduled, with the slowness having been introduced within the rather recent commits.

In this slow state, almost two minutes  may pass between workload being submitted and actually being started. An example timeline:

```
*   0 s: workload pod scheduled (`44:09`)
*   0 s: `44:09.410635       1 driver.go:120] PrepareResourceClaims called with 1 claim(s)` 
*   0 s: CD DS scheduled pod: "assigned ... imex-channel-injection-pmmhj-crntx to gb-nvl-043-compute09" (`44:09`)
*  45 s: last `FailedPrepareDynamicResources` / `context deadline exceeded` in workload pod (`44:54`)
*  45 s: `44:54.408795       1 driver.go:120] PrepareResourceClaims called with 1 claim(s)`
*  45 s: `44:54.422178       1 driver.go:199] Returning newly prepared devices for claim ... daemon-0`
*  45 s: compute-domain-daemon container started (`44:54`)
*  46 s: from logs: `IMEX Log initializing at: 5/20/2025 16:44:55.438`
* 109 s: `45:58.412919       1 driver.go:120] PrepareResourceClaims called with 1 claim(s)`
* 109 s: `45:58.421530       1 driver.go:199] Returning newly prepared devices for claim ... channel-0`
* 109 s: workload pod started (`45:58`)
```

Notably, the `compute-domain-daemon` container (part of a pod scheduled as part of the ComputeDomain daemonset) started 45 seconds after its wrapping pod had been scheduled.

@klueska had the hunch that that's because of a new "big" lock that the DRA library puts around "us" (the driver). Indeed, there now is a lock to serialize (un)prepare calls: https://github.com/kubernetes/dynamic-resource-allocation/blob/54da0bf688b5211b6fdc0bb051a763e6b3af911a/kubeletplugin/draplugin.go#L358

This patch disables said serialization mechanism.

We will have to investigate if the current synchronization primitives that we have in the driver (the work queue abstraction) is sufficient, or if that needs to be further consolidated.

With this patch, scheduling appears to be snappy again: in manual testing, I saw the ComputeDomain form around the workload with low latency again:
```
$ date
Tue May 20 13:22:00 PDT 2025
$ kubectl apply -f imex-channel-injection.yaml
computedomain.resource.nvidia.com/imex-channel-injection created
pod/imex-channel-injection created
$ kubectl get pods
NAME                     READY   STATUS    RESTARTS   AGE
imex-channel-injection   1/1     Running   0          5s
$ date
Tue May 20 13:22:08 PDT 2025
```