### PR TITLE
Replace in-mem (un)prep lock with file-based lock

### DIFF
--- a/pkg/flock/flock.go
+++ b/pkg/flock/flock.go
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2025 NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package flock
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+type Flock struct {
+	path string
+}
+
+type AcquireOption func(*acquireConfig)
+
+type acquireConfig struct {
+	timeout    time.Duration
+	pollPeriod time.Duration
+}
+
+func WithTimeout(timeout time.Duration) AcquireOption {
+	return func(cfg *acquireConfig) {
+		cfg.timeout = timeout
+	}
+}
+
+func WithPollPeriod(period time.Duration) AcquireOption {
+	return func(cfg *acquireConfig) {
+		cfg.pollPeriod = period
+	}
+}
+
+func NewFlock(path string) *Flock {
+	return &Flock{
+		path: path,
+	}
+}
+
+// Acquire attempts to acquire an exclusive file lock, polling with the configured
+// PollPeriod until whichever comes first:
+//
+// - lock successfully acquired
+// - timeout (if provided)
+// - external cancellation of context
+//
+// Returns a release function that must be called to unlock the file, typically
+// with defer().
+//
+// Introduced to protect the work in nodePrepareResource() and
+// nodeUnprepareResource() under a file-based lock because more than one driver
+// pod may be running on a node, but at most one such function must execute at
+// any given time.
+func (l *Flock) Acquire(ctx context.Context, opts ...AcquireOption) (func(), error) {
+	cfg := &acquireConfig{
+		// Default: short period to keep lock acquisition rather responsive
+		pollPeriod: 200 * time.Millisecond,
+		// Default: timeout disabled
+		timeout: 0,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	f, oerr := os.OpenFile(l.path, os.O_RDWR|os.O_CREATE, 0644)
+	if oerr != nil {
+		return nil, fmt.Errorf("error opening lock file (%s): %w", l.path, oerr)
+	}
+
+	t0 := time.Now()
+	ticker := time.NewTicker(cfg.pollPeriod)
+	defer ticker.Stop()
+
+	// Use non-blocking peek with LOCK_NB flag and polling; trade-off:
+	//
+	// - pro: no need for having to reliably cancel a potentially long-blocking
+	//   flock() system call (can only be done with signals).
+	// - con: lock acquisition time after a release is not immediate, but may
+	//   take up to PollPeriod amount of time. Not an issue in this context.
+	for {
+		flerr := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if flerr == nil {
+			// Lock acquired. Return release function. An exclusive flock() lock
+			// gets released when its file descriptor gets closed (also true
+			// when the lock-holding process crashes).
+			release := func() {
+				f.Close()
+			}
+			return release, nil
+		}
+
+		if flerr != syscall.EWOULDBLOCK {
+			// May be EBADF, EINTR, EINVAl, ENOLCK, and
+			// in general we want an outer retry mechanism
+			// to retry in view of any of those.
+			f.Close()
+			return nil, fmt.Errorf("error acquiring lock (%s): %w", l.path, flerr)
+		}
+
+		// Lock is currently held by other entity. Check for exit criteria;
+		// otherwise retry lock acquisition upon next tick.
+
+		if cfg.timeout > 0 && time.Since(t0) > cfg.timeout {
+			f.Close()
+			return nil, fmt.Errorf("timeout acquiring lock (%s)", l.path)
+		}
+
+		select {
+		case <-ctx.Done():
+			f.Close()
+			return nil, fmt.Errorf("error acquiring lock (%s): %w", l.path, ctx.Err())
+		case <-ticker.C:
+			// Retry flock().
+			continue
+		}
+	}
+}


### PR DESCRIPTION
After https://github.com/NVIDIA/k8s-dra-driver-gpu/pull/374, we need to implement our own synchronization primitive that coordinates multiple driver pods running at the same time.

This patch introduces a file-based lock (using Linux' [`flock()`](https://man7.org/linux/man-pages/man2/flock.2.html) system call).

I tested the program's behavior in case lock acquisition takes longer than expected, and recommend that we timeout-control the lock acquisition. One can do that
* either by using `LOCK_NB` combined with periodic polling
* or by running the blocking call in a timeout-controlled go routine

For now, I opted for the latter.

Edit: after thinking through the challenge of how to reliably cancel a blocking flock() system call (only with a (posix) signal), we opted for the first approach. The trade-off between both approaches is documented in a code comment.

#### Without timeout control

Acquired the lock out of band (OOB) with
```
$ flock pu.lock sleep 3000
```
and held on to it for a couple of minutes before releasing the lock again (Ctrl+C). While holding the OOB lock I triggered CD deletion.

Log output (see below) shows that in this case
* the main execution flow indeed stops (that includes request handlers)
* the `ctx, cancel := context.WithTimeout(ctx, ErrorRetryMaxTimeout)`  magic which is wrapping the lock acquisition does not actually unblock the main execution flow after 45 seconds (we get to see `client rate limiter Wait returned an error: context canceled`, but only after lock acquisition succeeded).

```
E0527 18:54:43.718106       1 workqueue.go:99] Failed to reconcile work item: error unpreparing devices for claim 'default/imex-channel-injection-imex-channel-0-pt4vg:7f15c281-61fb-417b-8274-6c8659fb30d1': unprepare devices failed: error removing Node label for ComputeDomain: error retrieving Node: client rate limiter Wait returned an error: context canceled
I0527 18:54:43.718161       1 nonblockinggrpcserver.go:159] "handling request succeeded" logger="dra" requestID=6 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" response="&NodeUnprepareResourcesResponse{Claims:map[string]*NodeUnprepareResourceResponse{},}"
I0527 18:54:43.718249       1 driver.go:177] UnprepareResourceClaims called with 1 claim(s)
I0527 18:54:43.718310       1 nonblockinggrpcserver.go:159] "handling request succeeded" logger="dra" requestID=7 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" response="&NodeUnprepareResourcesResponse{Claims:map[string]*NodeUnprepareResourceResponse{},}"
I0527 18:54:43.718340       1 driver.go:177] UnprepareResourceClaims called with 1 claim(s)
I0527 18:54:43.718357       1 nonblockinggrpcserver.go:159] "handling request succeeded" logger="dra" requestID=8 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" response="&NodeUnprepareResourcesResponse{Claims:map[string]*NodeUnprepareResourceResponse{},}"
I0527 18:54:43.718368       1 driver.go:177] UnprepareResourceClaims called with 1 claim(s)
I0527 18:54:43.718382       1 nonblockinggrpcserver.go:159] "handling request succeeded" logger="dra" requestID=9 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" response="&NodeUnprepareResourcesResponse{Claims:map[string]*NodeUnprepareResourceResponse{},}"
I0527 18:54:43.718392       1 driver.go:177] UnprepareResourceClaims called with 1 claim(s)
I0527 18:54:43.718408       1 nonblockinggrpcserver.go:159] "handling request succeeded" logger="dra" requestID=10 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" response="&NodeUnprepareResourcesResponse{Claims:map[string]*NodeUnprepareResourceResponse{},}"
I0527 18:54:43.718417       1 driver.go:177] UnprepareResourceClaims called with 1 claim(s)
I0527 18:54:43.718429       1 nonblockinggrpcserver.go:159] "handling request succeeded" logger="dra" requestID=11 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" response="&NodeUnprepareResourcesResponse{Claims:map[string]*NodeUnprepareResourceResponse{},}"
I0527 18:54:43.718439       1 driver.go:177] UnprepareResourceClaims called with 1 claim(s)
I0527 18:54:43.718453       1 nonblockinggrpcserver.go:159] "handling request succeeded" logger="dra" requestID=12 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" response="&NodeUnprepareResourcesResponse{Claims:map[string]*NodeUnprepareResourceResponse{},}"
I0527 18:54:43.718463       1 driver.go:177] UnprepareResourceClaims called with 1 claim(s)
I0527 18:54:43.725839       1 round_trippers.go:632] "Response" logger="dra" requestID=13 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" verb="GET" url="https://10.96.0.1:443/api/v1/nodes/sc-starwars-mab6-b00" status="200 OK" milliseconds=1
I0527 18:54:43.733482       1 round_trippers.go:632] "Response" logger="dra" requestID=13 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" verb="PUT" url="https://10.96.0.1:443/api/v1/nodes/sc-starwars-mab6-b00" status="200 OK" milliseconds=7
I0527 18:54:43.734795       1 driver.go:247] unprepared devices for claim 'default/imex-channel-injection-imex-channel-0-pt4vg:7f15c281-61fb-417b-8274-6c8659fb30d1'
I0527 18:54:43.734893       1 nonblockinggrpcserver.go:159] "handling request succeeded" logger="dra" requestID=13 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" response="&NodeUnprepareResourcesResponse{Claims:map[string]*NodeUnprepareResourceResponse{7f15c281-61fb-417b-8274-6c8659fb30d1: &NodeUnprepareResourceResponse{Error:,},},}"
```

Btw, I am not sure, but maybe we have queued up `NodeUnprepareResources` requests here unnecessarily (duplicates). That's an independent discussion.

#### With timeout control

```
I0527 20:26:32.451032       1 nonblockinggrpcserver.go:148] "handling request" logger="dra" requestID=6 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" request="&NodeUnprepareResourcesRequest{Claims:[]*Claim{&Claim{Namespace:default,UID:a97a4a27-1234-4aec-9468-eb27595f1abc,Name:imex-channel-injection-imex-channel-0-96fjl,},},}"
I0527 20:26:32.451123       1 driver.go:194] UnprepareResourceClaims called with 1 claim(s)
E0527 20:26:42.456923       1 workqueue.go:99] Failed to reconcile work item: error acquiring prep/unprep lock: timeout acquiring lock (/var/lib/kubelet/plugins/compute-domain.nvidia.com/pu.lock)
E0527 20:26:52.467499       1 workqueue.go:99] Failed to reconcile work item: error acquiring prep/unprep lock: timeout acquiring lock (/var/lib/kubelet/plugins/compute-domain.nvidia.com/pu.lock)
E0527 20:27:02.488767       1 workqueue.go:99] Failed to reconcile work item: error acquiring prep/unprep lock: timeout acquiring lock (/var/lib/kubelet/plugins/compute-domain.nvidia.com/pu.lock)
E0527 20:27:12.529298       1 workqueue.go:99] Failed to reconcile work item: error acquiring prep/unprep lock: timeout acquiring lock (/var/lib/kubelet/plugins/compute-domain.nvidia.com/pu.lock)
I0527 20:27:18.221793       1 nonblockinggrpcserver.go:148] "handling request" logger="dra" requestID=7 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" request="&NodeUnprepareResourcesRequest{Claims:[]*Claim{&Claim{Namespace:default,UID:a97a4a27-1234-4aec-9468-eb27595f1abc,Name:imex-channel-injection-imex-channel-0-96fjl,},},}"
E0527 20:27:22.610273       1 workqueue.go:99] Failed to reconcile work item: error acquiring prep/unprep lock: timeout acquiring lock (/var/lib/kubelet/plugins/compute-domain.nvidia.com/pu.lock)
I0527 20:27:22.610312       1 nonblockinggrpcserver.go:159] "handling request succeeded" logger="dra" requestID=6 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" response="&NodeUnprepareResourcesResponse{Claims:map[string]*NodeUnprepareResourceResponse{},}"
I0527 20:27:22.610396       1 driver.go:194] UnprepareResourceClaims called with 1 claim(s)
E0527 20:27:32.616021       1 workqueue.go:99] Failed to reconcile work item: error acquiring prep/unprep lock: timeout acquiring lock (/var/lib/kubelet/plugins/compute-domain.nvidia.com/pu.lock)
E0527 20:27:42.626597       1 workqueue.go:99] Failed to reconcile work item: error acquiring prep/unprep lock: timeout acquiring lock (/var/lib/kubelet/plugins/compute-domain.nvidia.com/pu.lock)
E0527 20:27:52.647488       1 workqueue.go:99] Failed to reconcile work item: error acquiring prep/unprep lock: timeout acquiring lock (/var/lib/kubelet/plugins/compute-domain.nvidia.com/pu.lock)
E0527 20:28:02.688710       1 workqueue.go:99] Failed to reconcile work item: error acquiring prep/unprep lock: timeout acquiring lock (/var/lib/kubelet/plugins/compute-domain.nvidia.com/pu.lock)
I0527 20:28:03.289349       1 nonblockinggrpcserver.go:148] "handling request" logger="dra" requestID=8 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" request="&NodeUnprepareResourcesRequest{Claims:[]*Claim{&Claim{Namespace:default,UID:a97a4a27-1234-4aec-9468-eb27595f1abc,Name:imex-channel-injection-imex-channel-0-96fjl,},},}"
E0527 20:28:12.770070       1 workqueue.go:99] Failed to reconcile work item: error acquiring prep/unprep lock: timeout acquiring lock (/var/lib/kubelet/plugins/compute-domain.nvidia.com/pu.lock)
I0527 20:28:12.770108       1 nonblockinggrpcserver.go:159] "handling request succeeded" logger="dra" requestID=7 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" response="&NodeUnprepareResourcesResponse{Claims:map[string]*NodeUnprepareResourceResponse{},}"
I0527 20:28:12.770160       1 driver.go:194] UnprepareResourceClaims called with 1 claim(s)
I0527 20:28:19.139593       1 round_trippers.go:632] "Response" logger="dra" requestID=8 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" verb="GET" url="https://10.96.0.1:443/api/v1/nodes/sc-starwars-mab6-b00" status="200 OK" milliseconds=1
I0527 20:28:19.147019       1 round_trippers.go:632] "Response" logger="dra" requestID=8 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" verb="PUT" url="https://10.96.0.1:443/api/v1/nodes/sc-starwars-mab6-b00" status="200 OK" milliseconds=6
I0527 20:28:19.148049       1 driver.go:264] unprepared devices for claim 'default/imex-channel-injection-imex-channel-0-96fjl:a97a4a27-1234-4aec-9468-eb27595f1abc'
```