### PR TITLE
Fix bug in updating node status in compute-domain-daemon

### DIFF
--- a/cmd/compute-domain-daemon/computedomain.go
+++ b/cmd/compute-domain-daemon/computedomain.go
@@ -169,6 +169,11 @@ func (m *ComputeDomainManager) UpdateComputeDomainNodeInfo(ctx context.Context, 
 	// Unconditionally update its IP address
 	nodeInfo.IPAddress = m.config.podIP
 
+	// Conditionally update its status
+	if newCD.Status.Status == "" {
+		newCD.Status.Status = nvapi.ComputeDomainStatusNotReady
+	}
+
 	// Update the status
 	if _, err := m.config.clientsets.Nvidia.ResourceV1beta1().ComputeDomains(newCD.Namespace).UpdateStatus(ctx, newCD, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("error updating nodes in ComputeDomain status: %w", err)


### PR DESCRIPTION
Without this we were getting:
```
E0603 13:54:40.778179       1 workqueue.go:99] Failed to reconcile work item: error updating node info in ComputeDomain: error updating nodes in ComputeDomain status: ComputeDomain.resource.nvidia.com "nvbandwidth-test-compute-domain" is invalid: [status.status: Unsupported value: "": supported values: "Ready", "NotReady", <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
```

The reason I didn't see this in my testing before merging https://github.com/NVIDIA/k8s-dra-driver-gpu/pull/383 is that I had an extra commit on top that allowed things to work without this.