### PR TITLE
Migrate checkpoint format from the format in 25.3.0-rc.2 to the latest

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/checkpoint_legacy.go
+++ b/cmd/compute-domain-kubelet-plugin/checkpoint_legacy.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"encoding/json"
+
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+	drapbv1 "k8s.io/kubelet/pkg/apis/dra/v1beta1"
+	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
+)
+
+// Legacy structs and methods to help with conversion as necessary.
+type PreparedDeviceList2503RC2 []PreparedDevice2503RC2
+type PreparedDevices2503RC2 []*PreparedDeviceGroup2503RC2
+type PreparedClaims2503RC2 map[string]PreparedDevices2503RC2
+
+type PreparedDevice2503RC2 struct {
+	Channel *PreparedComputeDomainChannel2503RC2 `json:"channel"`
+	Daemon  *PreparedComputeDomainDaemon2503RC2  `json:"daemon"`
+}
+
+type PreparedComputeDomainChannel2503RC2 struct {
+	Info   *ComputeDomainChannelInfo `json:"info"`
+	Device *drapbv1.Device           `json:"device"`
+}
+
+type PreparedComputeDomainDaemon2503RC2 struct {
+	Info   *ComputeDomainDaemonInfo `json:"info"`
+	Device *drapbv1.Device          `json:"device"`
+}
+
+type PreparedDeviceGroup2503RC2 struct {
+	Devices     PreparedDeviceList2503RC2 `json:"devices"`
+	ConfigState DeviceConfigState         `json:"configState"`
+}
+
+type Checkpoint2503RC2 struct {
+	Checksum checksum.Checksum    `json:"checksum"`
+	V1       *Checkpoint2503RC2V1 `json:"v1,omitempty"`
+}
+
+type Checkpoint2503RC2V1 struct {
+	PreparedClaims PreparedClaims2503RC2 `json:"preparedClaims,omitempty"`
+}
+
+func (cp *Checkpoint2503RC2) MarshalCheckpoint() ([]byte, error) {
+	cp.Checksum = 0
+	out, err := json.Marshal(*cp)
+	if err != nil {
+		return nil, err
+	}
+	cp.Checksum = checksum.New(out)
+	return json.Marshal(*cp)
+}
+
+func (cp *Checkpoint2503RC2) UnmarshalCheckpoint(data []byte) error {
+	return json.Unmarshal(data, cp)
+}
+
+func (cp *Checkpoint2503RC2) VerifyChecksum() error {
+	ck := cp.Checksum
+	cp.Checksum = 0
+	defer func() {
+		cp.Checksum = ck
+	}()
+	out, err := json.Marshal(*cp)
+	if err != nil {
+		return err
+	}
+	return ck.Verify(out)
+}
+
+// ToV1 converts a PreparedDevice2503RC2 to a PreparedDevice.
+func (d *PreparedDevice2503RC2) ToV1() PreparedDevice {
+	device := PreparedDevice{}
+	if d.Channel != nil {
+		device.Channel = d.Channel.ToV1()
+	}
+	if d.Daemon != nil {
+		device.Daemon = d.Daemon.ToV1()
+	}
+	return device
+}
+
+// ToV1 converts a PreparedComputeDomainChannel2503RC2 to a PreparedComputeDomainChannel.
+func (c *PreparedComputeDomainChannel2503RC2) ToV1() *PreparedComputeDomainChannel {
+	channel := &PreparedComputeDomainChannel{}
+	if c.Info != nil {
+		channel.Info = c.Info
+	}
+	if c.Device != nil {
+		channel.Device = &kubeletplugin.Device{
+			Requests:     c.Device.RequestNames,
+			PoolName:     c.Device.PoolName,
+			DeviceName:   c.Device.DeviceName,
+			CDIDeviceIDs: c.Device.CDIDeviceIDs,
+		}
+	}
+	return channel
+}
+
+// ToV1 converts a PreparedComputeDomainDaemon2503RC2 to a PreparedComputeDomainDaemon.
+func (d *PreparedComputeDomainDaemon2503RC2) ToV1() *PreparedComputeDomainDaemon {
+	daemon := &PreparedComputeDomainDaemon{}
+	if d.Info != nil {
+		daemon.Info = d.Info
+	}
+	if d.Device != nil {
+		daemon.Device = &kubeletplugin.Device{
+			Requests:     d.Device.RequestNames,
+			PoolName:     d.Device.PoolName,
+			DeviceName:   d.Device.DeviceName,
+			CDIDeviceIDs: d.Device.CDIDeviceIDs,
+		}
+	}
+	return daemon
+}
+
+// ToV1 converts a PreparedDeviceGroup2503RC2 to a PreparedDeviceGroup.
+func (g *PreparedDeviceGroup2503RC2) ToV1() *PreparedDeviceGroup {
+	group := &PreparedDeviceGroup{
+		Devices:     make(PreparedDeviceList, 0, len(g.Devices)),
+		ConfigState: g.ConfigState,
+	}
+	for _, d := range g.Devices {
+		group.Devices = append(group.Devices, d.ToV1())
+	}
+	return group
+}
+
+// ToV1 converts a Checkpoint2503RC2 to a Checkpoint.
+func (cp *Checkpoint2503RC2) ToV1() *Checkpoint {
+	cpv1 := newCheckpoint()
+	for k, v := range cp.V1.PreparedClaims {
+		pds := make(PreparedDevices, 0, len(v))
+		for _, pd := range v {
+			pds = append(pds, pd.ToV1())
+		}
+		cpv1.V1.PreparedClaims[k] = PreparedClaim{
+			PreparedDevices: pds,
+		}
+	}
+	return cpv1
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	k8s.io/component-base v0.33.0
 	k8s.io/dynamic-resource-allocation v0.33.0
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/kubelet v0.33.0
 	k8s.io/kubernetes v1.33.0
 	k8s.io/mount-utils v0.33.0
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
@@ -84,7 +85,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
-	k8s.io/kubelet v0.33.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect


### PR DESCRIPTION
Without this migration, trying to delete workloads after a driver upgrade will error out since the old checkpoint format wasn't being recognized. This change ensures a smooth migration.

The failure case was verified by:
1. Installing a DRA driver with `v25.3.0-rc.2`
2. Creating a ComputeDomain and launching a purposely failing workload
3. Uninstalling the DRA driver
4. Installing a DRA driver from `main` without this change (but with the udpated checkpoint code)
5. Attempting to delete the ComputeDomain and its workload (which both hang)
6. Observing the following error in the DRA kubelet-plugin logs:
```
E0604 16:48:20.957681       1 workqueue.go:99] Failed to reconcile work item: error unpreparing devices for claim 'default/nvbandwidth-test-worker-1-compute-domain-channel-w75tw:f7d8ecca-adb3-42e5-8fa0-1547217a2b3e': unable to get checkpoint: json: cannot unmarshal array into Go struct field CheckpointV1.v1.preparedClaims of type main.PreparedClaim
```

With this patch in place, and rerunning the procedure above -- step (5) completes, and the computeDomain and workload get cleaned up without error.