### PR TITLE
Bump version to 25.3.0-rc.3

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/Chart.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/Chart.yaml
@@ -19,10 +19,10 @@ description: Official Helm chart for the NVIDIA DRA Driver for GPUs
 type: application
 
 # Note(JP): strict semver: no v prefix allowed
-version: "25.3.0-rc.2"
+version: "25.3.0-rc.3"
 
 # Note(JP): templating logic consumes `appVersion` for building the default
 # `tag` value used in a k8s image specification. That logic expects the version
 # number below to not have a "v" prefix (a "v" is added by said logic to yield a
 # valid image reference).
-appVersion: "25.3.0-rc.2"
+appVersion: "25.3.0-rc.3"

--- a/versions.mk
+++ b/versions.mk
@@ -18,7 +18,7 @@ MODULE := github.com/NVIDIA/$(DRIVER_NAME)
 
 REGISTRY ?= nvcr.io/nvidia
 
-VERSION  ?= v25.3.0-rc.2
+VERSION  ?= v25.3.0-rc.3
 
 # vVERSION represents the version with a guaranteed v-prefix
 # Note: this is probably not consumed in our build chain.


### PR DESCRIPTION
In preparation for an upcoming release.

Reminder: we're still in pragmatic mode (no branches, no -devel or -dev suffix -- we will introduce these strategies soon enough).