### PR TITLE
Invalidate go build cache layer less often

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,6 @@
-/deployments/container
+.dockerignore
+deployments/container
+*.tar
+*.tgz
+demo
+.git

--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -1,3 +1,7 @@
+# syntax=docker.io/docker/dockerfile:1.7-labs
+# The above enables the COPY --exclude flag, see:
+# https://github.com/moby/buildkit/pull/4561
+
 # Copyright (c) 2019-2025, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,7 +50,16 @@ ENV GOPATH=/go
 ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
 
 WORKDIR /build
-COPY . .
+
+# Copy everything that is needed for the go build, but do not invalidate go
+# build artifact layer unnecessarily often. Note that --exclude only affects the
+# cache.
+COPY    --exclude=./templates/** \
+        --exclude=./deployments/helm/** \
+        --exclude=./hack/kubelet-plugin-prestart.sh \
+        --exclude=./demo/** \
+        --exclude=./Dockerfile \
+        . .
 
 RUN mkdir /artifacts
 
@@ -95,3 +108,4 @@ COPY --from=build   /artifacts/compute-domain-kubelet-plugin /usr/bin/compute-do
 COPY --from=build   /artifacts/compute-domain-daemon         /usr/bin/compute-domain-daemon
 COPY --from=build   /artifacts/gpu-kubelet-plugin            /usr/bin/gpu-kubelet-plugin
 COPY --from=build   /build/templates                         /templates
+COPY /templates /templates

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -87,6 +87,7 @@ $(IMAGE_TARGETS): image-%:
 		--build-arg TOOLKIT_CONTAINER_IMAGE="$(TOOLKIT_CONTAINER_IMAGE)" \
 		--build-arg VERSION="$(VERSION)" \
 		--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
+		--progress=plain \
 		-f $(DOCKERFILE) \
 		$(CURDIR)
 


### PR DESCRIPTION
The go build takes slightly more than one minute on my machine, and about ~30 seconds on a fast multi-core box. The go build contributes almost 100 % to the image build time.

It's currently triggered when changing _any_ file in the build context because we `COPY . .` before invoking the build.

This is of course useful in order to make sure we never accidentally don't invalidate. As we all know... missing cache invalidation can be one of the most annoying things.

But I think we should work towards a trade-off here. Mutation of certain files (think: allow-listing) should _not_ invalidate the go build.

This comes from the perspective of rebuilding at high frequency during local dev / bisection / debugging / dev.