### PR TITLE
Update README to reflect current state of project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contribute to the NVIDIA Kubernetes DRA Driver
+# Contribute to the NVIDIA DRA Driver for GPUs
 
-Want to hack on the NVIDIA Kubernetes DRA Driver Project? Awesome!
+Want to hack on the NVIDIA DRA Driver for GPUs? Awesome!
 We only require you to sign your work, the below section describes this!
 
 ## Sign your work


### PR DESCRIPTION
As has been pointed out by many (and is known to us), the README at this point is rather out of date. It doesn't communicate some important aspects.

This is a first step towards revamping the README. Some goals I wanted to get done in this patch:

- clarify the two parts of the driver
- declare what's supported and what not
- use the name that we settled on
- link out to current installation instructions
- link out to useful DRA docs
- link out to our "road map" (in the rc.3 release notes)

Rendered version: https://github.com/jgehrcke/k8s-dra-driver-gpu/blob/jp/readme/README.md

I'd love to not iterate on this forever. I find it obvious that in the future we want more content in there! :) Especially CONTRIBUTING/development notes. I don't want to do everything at once, let's land patches step by step.