### PR TITLE
Fix COPYing files during container image build

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -107,6 +107,5 @@ COPY --from=build   /artifacts/compute-domain-controller     /usr/bin/compute-do
 COPY --from=build   /artifacts/compute-domain-kubelet-plugin /usr/bin/compute-domain-kubelet-plugin
 COPY --from=build   /artifacts/compute-domain-daemon         /usr/bin/compute-domain-daemon
 COPY --from=build   /artifacts/gpu-kubelet-plugin            /usr/bin/gpu-kubelet-plugin
-COPY --from=build   /build/hack/kubelet-plugin-prestart.sh   /usr/bin/kubelet-plugin-prestart.sh
-COPY --from=build   /build/templates                         /templates
+COPY /hack/kubelet-plugin-prestart.sh /usr/bin/kubelet-plugin-prestart.sh
 COPY /templates /templates


### PR DESCRIPTION
Saw this error in a PR:
```
#32 [linux/arm64 stage-2  8/10] COPY --from=build   /build/hack/kubelet-plugin-prestart.sh   /usr/bin/kubelet-plugin-prestart.sh
#32 ERROR: failed to calculate checksum of ref 5wfxwomvcudkv8hvxwvvv5v1m::8l94fefycjhuykgu9u6rrbako: "/build/hack/kubelet-plugin-prestart.sh": not found
```
[logs](https://github.com/NVIDIA/k8s-dra-driver-gpu/actions/runs/16029796749/job/45227405797?pr=416#step:7:1200)

#397 introduced that problem, partly because I started working on it before landing https://github.com/NVIDIA/k8s-dra-driver-gpu/pull/389.

The last CI run on #379 wasn't quite authoritative.


