### PR TITLE
Use device minor as suffix in device name instead of the index

### DIFF
--- a/cmd/gpu-kubelet-plugin/deviceinfo.go
+++ b/cmd/gpu-kubelet-plugin/deviceinfo.go
@@ -68,11 +68,11 @@ func (p MigProfileInfo) String() string {
 }
 
 func (d *GpuInfo) CanonicalName() string {
-	return fmt.Sprintf("gpu-%d", d.index)
+	return fmt.Sprintf("gpu-%d", d.minor)
 }
 
 func (d *MigDeviceInfo) CanonicalName() string {
-	return fmt.Sprintf("gpu-%d-mig-%d-%d-%d", d.parent.index, d.giInfo.ProfileId, d.placement.Start, d.placement.Size)
+	return fmt.Sprintf("gpu-%d-mig-%d-%d-%d", d.parent.minor, d.giInfo.ProfileId, d.placement.Start, d.placement.Size)
 }
 
 func (d *GpuInfo) CanonicalIndex() string {


### PR DESCRIPTION
The device minor is more stable than the index in terms of not changing once a node has been brought online. The minor number may change across a node reboot, but it wont change if one of the GPUs falls off the bus or is explicitly drained / blocklisted from the driver (whereas the index will adjust for any missing GPUs).

Fixes #427 