### PR TITLE
Use mutation cache in addition to informer cache in CD controller

### DIFF
--- a/cmd/compute-domain-controller/computedomain.go
+++ b/cmd/compute-domain-controller/computedomain.go
@@ -33,7 +33,14 @@ import (
 type GetComputeDomainFunc func(uid string) (*nvapi.ComputeDomain, error)
 
 const (
+	// informerResyncPeriod defines how often the informer will resync its cache
+	// with the API server. This helps ensure eventual consistency.
 	informerResyncPeriod = 10 * time.Minute
+
+	// mutationCacheTTL defines how long mutation cache entries remain valid.
+	// This should be long enough for the informer cache to catch up but
+	// not so long that stale entries cause issues.
+	mutationCacheTTL = time.Hour
 
 	computeDomainLabelKey  = "resource.nvidia.com/computeDomain"
 	computeDomainFinalizer = computeDomainLabelKey


### PR DESCRIPTION
Please see https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/440 for a detailed description of what motivated this change.

Fixes https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/440

Tested with the following script which runs 100 back-to-back iterations of the `nvbandwidth` test from https://github.com/NVIDIA/k8s-dra-driver-gpu/discussions/249. It took ~50 min to run to completion:
```
#!/bin/bash

MAX_ITER=100
TIMEOUT=300  # 5 minutes in seconds

for ((i=1; i<=MAX_ITER; i++)); do
    echo "Starting iteration $i"

    kubectl apply -f nvbandwidth-test-job.yaml

    # Wait up to TIMEOUT seconds for the pod to complete
    SECONDS=0
    while true; do
        STATUS=$(kubectl get pod -l job-name=nvbandwidth-test-launcher -o jsonpath="{.items[0].status.phase}" 2>/dev/null)

        if [ "$STATUS" == "Succeeded" ]; then
            echo "Pod completed successfully."
            break
        elif [ "$STATUS" == "Failed" ]; then
            echo "Pod failed."
            break
        elif [ "$SECONDS" -ge $TIMEOUT ]; then
            echo "Timeout reached ($TIMEOUT seconds). Exiting loop."
            exit 1
        fi

        sleep 5
    done

    kubectl delete -f nvbandwidth-test-job.yaml
done

echo "Finished $MAX_ITER iterations successfully."
```

Results:
```
Starting iteration 1
computedomain.resource.nvidia.com/nvbandwidth-test-compute-domain created
mpijob.kubeflow.org/nvbandwidth-test created
Pod completed successfully.
computedomain.resource.nvidia.com "nvbandwidth-test-compute-domain" deleted
mpijob.kubeflow.org "nvbandwidth-test" deleted

...

Starting iteration 100
computedomain.resource.nvidia.com/nvbandwidth-test-compute-domain created
mpijob.kubeflow.org/nvbandwidth-test created
Pod completed successfully.
Finished 100 iterations successfully.
```