### PR TITLE
[no-relnote] Fix publish image tags

### DIFF
--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -234,7 +234,8 @@ push-images-to-staging:
       fi
 
       rm -f ${VERSION_FILE}
-      echo "${IN_IMAGE_TAG} ${OUT_IMAGE_TAG}-ubi9" >> ${VERSION_FILE}
+      echo "${IN_IMAGE_TAG}-ubi9 ${OUT_IMAGE_TAG}-ubi9" >> ${VERSION_FILE}
+      echo "${IN_IMAGE_TAG}-ubi9 ${OUT_IMAGE_TAG}" >> ${VERSION_FILE}
       cat ${VERSION_FILE}
   script:
     - cnt-ngc-publish render --project-name "${PROJECT_NAME}" --versions-file "${VERSION_FILE}" --output "${PROJECT_NAME}".yaml


### PR DESCRIPTION
#443 added the image suffix to the target image, but not the source image.

This change ensures that:
1. Both the source and target image have the image suffix added.
2. Adds a target image without the `-ubi9` suffix. 

The latter means that we can start referring to an image with only the version tag before we update our internal tooling to remove the `-ubi9` suffix.