### PR TITLE
[no-relnote] Override publishing path

### DIFF
--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -226,12 +226,16 @@ push-images-to-staging:
     PROJECT_NAME: "k8s-dra-driver-gpu"
   before_script:
     - |
-      if [ -z "$NGC_PUBLISHING_PROJECT_PATH" ]; then
+      if [ -n "${OVERRIDE_PUBLISHING_PROJECT_PATH}" ]; then
+        NGC_PUBLISHING_PROJECT_PATH="${OVERRIDE_PUBLISHING_PROJECT_PATH}"
+      fi
+
+      if [ -z "${NGC_PUBLISHING_PROJECT_PATH}" ]; then
         echo "NGC_PUBLISHING_PROJECT_PATH not set"
         exit 1
-      else
-        echo "publishing to ${NGC_PUBLISHING_PROJECT_PATH}"
       fi
+
+      echo "publishing to ${NGC_PUBLISHING_PROJECT_PATH}"
 
       rm -f ${VERSION_FILE}
       echo "${IN_IMAGE_TAG}-ubi9 ${OUT_IMAGE_TAG}-ubi9" >> ${VERSION_FILE}
@@ -258,8 +262,7 @@ publish-images-dummy:
   extends:
     - .publish-images
   variables:
-    NGC_PUBLISHING_PROJECT_PATH: dl/container-dev/ngc-automation
+    OVERRIDE_PUBLISHING_PROJECT_PATH: "dl/container-dev/ngc-automation"
     OUT_IMAGE_TAG: "publish-${CI_COMMIT_SHORT_SHA}"
   rules:
     - if: $CI_COMMIT_TAG == null || $CI_COMMIT_TAG == ""
-


### PR DESCRIPTION
The project or group CI variables have a higher precedence than variables at a job level. This means that the dummy publishing job also publishes a "real" MR.

This change ensures that we explicitly override the global value.

See https://github.com/NVIDIA/nvidia-container-toolkit/pull/1211 where this was done for the toolkit.