### PR TITLE
Update nvidia-container-toolkit module reference to v1.18.0-rc.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/NVIDIA/go-nvlib v0.7.3
 	github.com/NVIDIA/go-nvml v0.12.9-0
-	github.com/NVIDIA/nvidia-container-toolkit v1.18.0-rc.1.0.20250730085513-4f98c014bfa1
+	github.com/NVIDIA/nvidia-container-toolkit v1.18.0-rc.2
 	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/NVIDIA/go-nvlib v0.7.3 h1:kXc8PkWUlrwedSpM4fR8xT/DAq1NKy8HqhpgteFcGAw
 github.com/NVIDIA/go-nvlib v0.7.3/go.mod h1:i95Je7GinMy/+BDs++DAdbPmT2TubjNP8i8joC7DD7I=
 github.com/NVIDIA/go-nvml v0.12.9-0 h1:e344UK8ZkeMeeLkdQtRhmXRxNf+u532LDZPGMtkdus0=
 github.com/NVIDIA/go-nvml v0.12.9-0/go.mod h1:+KNA7c7gIBH7SKSJ1ntlwkfN80zdx8ovl4hrK3LmPt4=
-github.com/NVIDIA/nvidia-container-toolkit v1.18.0-rc.1.0.20250730085513-4f98c014bfa1 h1:G1E4TuPBijzn4EuEnRwzZ64HGjcTjKwTrH2H3GN1NZw=
-github.com/NVIDIA/nvidia-container-toolkit v1.18.0-rc.1.0.20250730085513-4f98c014bfa1/go.mod h1:z0KTZNkSOiQx8u4SEo1iq0aldqdnwruLHPXHdMd3B+k=
+github.com/NVIDIA/nvidia-container-toolkit v1.18.0-rc.2 h1:vjEJpEpiGhGqca+JK9p0RqmCIBZPnOpPyT1nPj4nsEM=
+github.com/NVIDIA/nvidia-container-toolkit v1.18.0-rc.2/go.mod h1:z0KTZNkSOiQx8u4SEo1iq0aldqdnwruLHPXHdMd3B+k=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,7 +9,7 @@ github.com/NVIDIA/go-nvlib/pkg/nvlib/info
 ## explicit; go 1.20
 github.com/NVIDIA/go-nvml/pkg/dl
 github.com/NVIDIA/go-nvml/pkg/nvml
-# github.com/NVIDIA/nvidia-container-toolkit v1.18.0-rc.1.0.20250730085513-4f98c014bfa1
+# github.com/NVIDIA/nvidia-container-toolkit v1.18.0-rc.2
 ## explicit; go 1.23.2
 github.com/NVIDIA/nvidia-container-toolkit/internal/config/image
 github.com/NVIDIA/nvidia-container-toolkit/internal/discover


### PR DESCRIPTION
This change updates the nvidia-container-toolkit go dependency to v1.18.0-rc.2. This tag was not present with the last dependency bump and has since been created. Note that this is a purely cosmetic change and there are no changes in vendored functionality.