### PR TITLE
replace calls of deprecated method MinimumRequiredVersion()

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/cdi.go
+++ b/cmd/compute-domain-kubelet-plugin/cdi.go
@@ -191,9 +191,9 @@ func (cdi *CDIHandler) CreateStandardDeviceSpecFile(allocatable AllocatableDevic
 	}
 
 	// Update the spec to include only the minimum version necessary.
-	minVersion, err := cdiapi.MinimumRequiredVersion(spec.Raw())
+	minVersion, err := cdispec.MinimumRequiredVersion(spec.Raw())
 	if err != nil {
-		return fmt.Errorf("failed to get minimum required CDI spec version: %v", err)
+		return fmt.Errorf("failed to get minimum required CDI spec version: %w", err)
 	}
 	spec.Raw().Version = minVersion
 
@@ -248,9 +248,9 @@ func (cdi *CDIHandler) CreateClaimSpecFile(claimUID string, preparedDevices Prep
 	}
 
 	// Update the spec to include only the minimum version necessary.
-	minVersion, err := cdiapi.MinimumRequiredVersion(spec.Raw())
+	minVersion, err := cdispec.MinimumRequiredVersion(spec.Raw())
 	if err != nil {
-		return fmt.Errorf("failed to get minimum required CDI spec version: %v", err)
+		return fmt.Errorf("failed to get minimum required CDI spec version: %w", err)
 	}
 	spec.Raw().Version = minVersion
 

--- a/cmd/gpu-kubelet-plugin/cdi.go
+++ b/cmd/gpu-kubelet-plugin/cdi.go
@@ -196,9 +196,9 @@ func (cdi *CDIHandler) CreateStandardDeviceSpecFile(allocatable AllocatableDevic
 	}
 
 	// Update the spec to include only the minimum version necessary.
-	minVersion, err := cdiapi.MinimumRequiredVersion(spec.Raw())
+	minVersion, err := cdispec.MinimumRequiredVersion(spec.Raw())
 	if err != nil {
-		return fmt.Errorf("failed to get minimum required CDI spec version: %v", err)
+		return fmt.Errorf("failed to get minimum required CDI spec version: %w", err)
 	}
 	spec.Raw().Version = minVersion
 
@@ -253,9 +253,9 @@ func (cdi *CDIHandler) CreateClaimSpecFile(claimUID string, preparedDevices Prep
 	}
 
 	// Update the spec to include only the minimum version necessary.
-	minVersion, err := cdiapi.MinimumRequiredVersion(spec.Raw())
+	minVersion, err := cdispec.MinimumRequiredVersion(spec.Raw())
 	if err != nil {
-		return fmt.Errorf("failed to get minimum required CDI spec version: %v", err)
+		return fmt.Errorf("failed to get minimum required CDI spec version: %w", err)
 	}
 	spec.Raw().Version = minVersion
 


### PR DESCRIPTION
Replace the deprecated method from the package `tags.cncf.io/container-device-interface/pkg/cdi` with the one from the package `tags.cncf.io/container-device-interface/specs-go`

Method definition below
```
// MinimumRequiredVersion determines the minimum spec version for the input spec.
// Deprecated: use cdi.MinimumRequiredVersion instead
func MinimumRequiredVersion(spec *cdi.Spec) (string, error) {
	return cdi.MinimumRequiredVersion(spec)
}
```