### PR TITLE
Add feature gates for TimeSlicing and MPS settings

### DIFF
--- a/api/nvidia.com/resource/v1beta1/migconfig.go
+++ b/api/nvidia.com/resource/v1beta1/migconfig.go
@@ -17,9 +17,9 @@
 package v1beta1
 
 import (
-	"fmt"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/NVIDIA/k8s-dra-driver-gpu/pkg/featuregates"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -32,32 +32,46 @@ type MigDeviceConfig struct {
 
 // DefaultMigDeviceConfig provides the default Mig Device configuration.
 func DefaultMigDeviceConfig() *MigDeviceConfig {
-	return &MigDeviceConfig{
+	config := &MigDeviceConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupName + "/" + Version,
 			Kind:       MigDeviceConfigKind,
 		},
-		Sharing: &MigDeviceSharing{
-			Strategy: TimeSlicingStrategy,
-		},
 	}
+
+	if featuregates.Enabled(featuregates.TimeSlicingSettings) {
+		config.Sharing = &MigDeviceSharing{
+			Strategy: TimeSlicingStrategy,
+		}
+	}
+
+	return config
 }
 
 // Normalize updates a MigDeviceConfig config with implied default values based on other settings.
 func (c *MigDeviceConfig) Normalize() error {
 	if c.Sharing == nil {
-		return nil
+		if !featuregates.Enabled(featuregates.TimeSlicingSettings) {
+			return nil
+		}
+		c.Sharing = &MigDeviceSharing{
+			Strategy: TimeSlicingStrategy,
+		}
 	}
-	if c.Sharing.Strategy == MpsStrategy && c.Sharing.MpsConfig == nil {
-		c.Sharing.MpsConfig = &MpsConfig{}
+
+	if featuregates.Enabled(featuregates.MPSSupport) {
+		if c.Sharing.Strategy == MpsStrategy && c.Sharing.MpsConfig == nil {
+			c.Sharing.MpsConfig = &MpsConfig{}
+		}
 	}
+
 	return nil
 }
 
 // Validate ensures that MigDeviceConfig has a valid set of values.
 func (c *MigDeviceConfig) Validate() error {
 	if c.Sharing == nil {
-		return fmt.Errorf("no sharing strategy set")
+		return nil
 	}
 	return c.Sharing.Validate()
 }

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -28,8 +28,11 @@ import (
 )
 
 const (
-	// ExampleFeature is a placeholder just to show how these gates are added.
-	ExampleFeature featuregate.Feature = "ExampleFeature"
+	// TimeSlicingSettings allows timeslicing settings to be customized.
+	TimeSlicingSettings featuregate.Feature = "TimeSlicingSettings"
+
+	// MPSSupport allows MPS (Multi-Process Service) settings to be specified.
+	MPSSupport featuregate.Feature = "MPSSupport"
 )
 
 // FeatureGates is a singleton representing the set of all feature gates and their values.
@@ -39,7 +42,14 @@ var FeatureGates featuregate.MutableVersionedFeatureGate
 // defaultFeatureGates contains the default settings for all project-specific feature gates.
 // These will be registered with the standard Kubernetes feature gate system.
 var defaultFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
-	ExampleFeature: {
+	TimeSlicingSettings: {
+		{
+			Default:    false,
+			PreRelease: featuregate.Alpha,
+			Version:    version.MajorMinor(25, 8),
+		},
+	},
+	MPSSupport: {
 		{
 			Default:    false,
 			PreRelease: featuregate.Alpha,

--- a/pkg/featuregates/featuregates_test.go
+++ b/pkg/featuregates/featuregates_test.go
@@ -131,11 +131,11 @@ func TestDefaultFeatureGates(t *testing.T) {
 
 		// Test that the system is functional by querying a real feature
 		require.NotPanics(t, func() {
-			_ = fg.Enabled(ExampleFeature)
-		}, "Should be able to query actual project features")
+			_ = fg.Enabled(TimeSlicingSettings)
+		}, "Should be able to query real features")
 
 		// Test that real features have expected defaults
-		require.False(t, fg.Enabled(ExampleFeature), "ExampleFeature should be disabled by default (alpha)")
+		require.False(t, fg.Enabled(TimeSlicingSettings), "TimeSlicingSettings should be disabled by default (alpha)")
 	})
 }
 
@@ -314,15 +314,15 @@ func TestKnownFeaturesIntegration(t *testing.T) {
 
 		require.NotEmpty(t, knownFeatures, "Should have known features")
 
-		// Verify that our real project features are included
+		// Verify that our real features are included
 		found := false
 		for _, feature := range knownFeatures {
-			if strings.Contains(feature, string(ExampleFeature)) {
+			if strings.Contains(feature, string(TimeSlicingSettings)) {
 				found = true
 				break
 			}
 		}
-		require.True(t, found, "Should contain our project features in known features list")
+		require.True(t, found, "Should contain our real features in known features list")
 	})
 
 	t.Run("TestFeatureGates", func(t *testing.T) {


### PR DESCRIPTION
Both feature gates have been added as alpha features and are off by default.

With these in place one needs to set `featureGates.TimeSlicingSettings=true` and/or `featureGates.MPSSupport=true` when installing the helm chart to enable these features.

Webhook validation works as expected when these are off, rejecting ResourceClaims and ResourceClaimTemplates that have configs for these features when they are disabled.

A quick smoke test with the feature gate disabled:
```
$ kubectl apply -f https://raw.githubusercontent.com/NVIDIA/k8s-dra-driver-gpu/refs/heads/main/demo
/specs/quickstart/gpu-test5.yaml
namespace/gpu-test5 created
pod/pod0 created
The request is invalid: error when creating "https://raw.githubusercontent.com/NVIDIA/k8s-dra-driver-gpu/refs/heads/main/demo/specs/quickstart/gpu-test5.yaml": admission webhook "gpu.nvidia.com" denied the request: 2 configs failed to validate: object at spec.spec.devices.config[0].opaque.parameters is invalid: unknown GPU sharing strategy: TimeSlicing; object at spec.spec.devices.config[1].opaque.parameters is invalid: unknown GPU sharing strategy: MPS
```