### PR TITLE
Update validatingadmissionpolicy to apply for v1, v1beta1, and v1beta2

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/templates/validatingadmissionpolicy.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/validatingadmissionpolicy.yaml
@@ -7,7 +7,7 @@ spec:
   matchConstraints:
     resourceRules:
     - apiGroups:   ["resource.k8s.io"]
-      apiVersions: ["v1beta1"]
+      apiVersions: ["v1", "v1beta1", "v1beta2"]
       operations:  ["CREATE", "UPDATE", "DELETE"]
       resources:   ["resourceslices"]
   matchConditions:


### PR DESCRIPTION
Without this change, `resourceslice` creation on behalf of our driver is not restricted to just our driver. Needs backporting to the `release-25.3` branch.