### PR TITLE
Update the version used during CI to match ${VERSION}-${SHORT_GIT_SHA}

### DIFF
--- a/.github/workflows/variables.yaml
+++ b/.github/workflows/variables.yaml
@@ -16,7 +16,7 @@ on:
   workflow_call:
     outputs:
       version:
-        description: "The short SHA to use as a version string"
+        description: "The version string with the commit short SHA attached"
         value: ${{ jobs.variables.outputs.version }}
       golang_version:
         description: "The golang version for this project"
@@ -32,9 +32,9 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v5
 
-    - name: Generate Commit Short SHA
+    - name: Get Version with Commit Short SHA
       id: version
-      run: echo "version=$(echo $GITHUB_SHA | cut -c1-8)" >> "$GITHUB_OUTPUT"
+      run: echo "version=$(make print-VERSION)-$(echo $GITHUB_SHA | cut -c1-8)" >> "$GITHUB_OUTPUT"
 
     - name: Get Golang Version
       id: golang_version

--- a/versions.mk
+++ b/versions.mk
@@ -36,3 +36,6 @@ BUILDIMAGE_TAG ?= devel-go$(GOLANG_VERSION)
 BUILDIMAGE ?=  $(DRIVER_NAME):$(BUILDIMAGE_TAG)
 
 GIT_COMMIT ?= $(shell git describe --match="" --dirty --long --always --abbrev=40 2> /dev/null || echo "")
+
+print-%:
+	@echo $($*)


### PR DESCRIPTION
Previously, it was just set as ${SHORT_GIT_SHA}, which caused problems with the latest changes to support feature gates which expects a version string to *always* be in semver form.

Fixes: https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/478