### PR TITLE
ComputeDomain: allow for injecting "all" IMEX channels

### DIFF
--- a/api/nvidia.com/resource/v1beta1/computedomain.go
+++ b/api/nvidia.com/resource/v1beta1/computedomain.go
@@ -23,6 +23,9 @@ import (
 const (
 	ComputeDomainStatusReady    = "Ready"
 	ComputeDomainStatusNotReady = "NotReady"
+
+	ComputeDomainChannelAllocationModeSingle = "Single"
+	ComputeDomainChannelAllocationModeAll    = "All"
 )
 
 // +genclient
@@ -61,6 +64,11 @@ type ComputeDomainSpec struct {
 // ComputeDomainChannelSpec provides the spec for a channel used to run a workload inside a ComputeDomain.
 type ComputeDomainChannelSpec struct {
 	ResourceClaimTemplate ComputeDomainResourceClaimTemplate `json:"resourceClaimTemplate"`
+	// Allows for requesting all IMEX channels (the maximum per IMEX domain) or
+	// precisely one.
+	// +kubebuilder:validation:Enum=All;Single
+	// +kubebuilder:default=Single
+	AllocationMode string `json:"allocationMode"`
 }
 
 // ComputeDomainResourceClaimTemplate provides the details of the ResourceClaimTemplate to generate.

--- a/api/nvidia.com/resource/v1beta1/computedomainconfig.go
+++ b/api/nvidia.com/resource/v1beta1/computedomainconfig.go
@@ -28,6 +28,7 @@ import (
 type ComputeDomainChannelConfig struct {
 	metav1.TypeMeta `json:",inline"`
 	DomainID        string `json:"domainID"`
+	AllocationMode  string `json:"allocationMode"`
 }
 
 // DefaultComputeDomainChannelConfig provides the default ComputeDomainChannel configuration.

--- a/cmd/compute-domain-controller/resourceclaimtemplate.go
+++ b/cmd/compute-domain-controller/resourceclaimtemplate.go
@@ -376,6 +376,7 @@ func (m *WorkloadResourceClaimTemplateManager) Create(ctx context.Context, names
 
 	channelConfig := nvapi.DefaultComputeDomainChannelConfig()
 	channelConfig.DomainID = string(cd.UID)
+	channelConfig.AllocationMode = cd.Spec.Channel.AllocationMode
 
 	templateData := ResourceClaimTemplateTemplateData{
 		Namespace:               namespace,

--- a/demo/specs/imex/channel-injection-all.yaml
+++ b/demo/specs/imex/channel-injection-all.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: resource.nvidia.com/v1beta1
+kind: ComputeDomain
+metadata:
+  name: imex-channel-injection-all
+spec:
+  numNodes: 1
+  channel:
+    allocationMode: All
+    resourceClaimTemplate:
+      name: tpl-imex-channels
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: imex-channel-injection-all
+spec:
+  containers:
+  - name: ctr
+    image: ubuntu:22.04
+    command: ["bash", "-c"]
+    args: ["ls -la /dev/nvidia-caps-imex-channels; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: imex-channels
+  resourceClaims:
+  - name: imex-channels
+    resourceClaimTemplateName: tpl-imex-channels

--- a/deployments/helm/nvidia-dra-driver-gpu/crds/resource.nvidia.com_computedomains.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/crds/resource.nvidia.com_computedomains.yaml
@@ -44,6 +44,15 @@ spec:
                 description: ComputeDomainChannelSpec provides the spec for a channel
                   used to run a workload inside a ComputeDomain.
                 properties:
+                  allocationMode:
+                    default: Single
+                    description: |-
+                      Allows for requesting all IMEX channels (the maximum per IMEX domain) or
+                      precisely one.
+                    enum:
+                    - All
+                    - Single
+                    type: string
                   resourceClaimTemplate:
                     description: ComputeDomainResourceClaimTemplate provides the details
                       of the ResourceClaimTemplate to generate.
@@ -54,6 +63,7 @@ spec:
                     - name
                     type: object
                 required:
+                - allocationMode
                 - resourceClaimTemplate
                 type: object
               numNodes:

--- a/templates/compute-domain-workload-claim-template.tmpl.yaml
+++ b/templates/compute-domain-workload-claim-template.tmpl.yaml
@@ -24,3 +24,4 @@ spec:
             apiVersion: {{ .ChannelConfig.APIVersion }}
             kind: {{ .ChannelConfig.Kind }}
             domainID: {{ .ChannelConfig.DomainID }}
+            allocationMode: {{ .ChannelConfig.AllocationMode }}


### PR DESCRIPTION
After lots of discussion, this is our current pragmatic solution strategy to help with https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/468.


After the last changes landed on `main`, I rebased and did another manual test to see if things are at least working;  yes:

```
19:08:06 ± helm install nvidia-dra-driver-gpu deployments/helm/nvidia-dra-driver-gpu/ --namespace nvidia-dra-driver-gpu --create-namespace --set
 resources.gpus.enabled=false --set nvidiaDriverRoot=/run/nvidia/driver && sleep 5 && kubectl apply -f demo/specs/imex/channel-injection-all.yam
l 
NAME: nvidia-dra-driver-gpu
LAST DEPLOYED: Thu Aug 28 19:08:32 2025
NAMESPACE: nvidia-dra-driver-gpu
STATUS: deployed
REVISION: 1
TEST SUITE: None
computedomain.resource.nvidia.com/imex-channel-injection-all created
pod/imex-channel-injection-all created
[jgehrcke@gb-nvl-043-bianca-5:~/dev/k8s-dra-driver-gpu] jp/all-channels+*
19:08:37 ± kubectl logs imex-channel-injection-all | wc -l
2051
```

Review appreciated, let's iterate later or tomorrow.