### PR TITLE
fix: compute domain startup probe on ipv6 with driver 580+

### DIFF
--- a/templates/compute-domain-daemon-config.tmpl.cfg
+++ b/templates/compute-domain-daemon-config.tmpl.cfg
@@ -197,7 +197,7 @@ IMEX_CMD_ENABLED=1
 
 #  Description:  IP address to use to bind the command/control service.  Ignored if IMEX_CMD_ENABLED=0
 #                If empty, (but IMEX_CMD_PORT is specified), it will bind to all available interfaces.
-IMEX_CMD_BIND_INTERFACE_IP=
+IMEX_CMD_BIND_INTERFACE_IP=127.0.0.1
 
 #  Description:  Port to bind to (in conjunction with IMEX_CMD_BIND_INTERFACE) for the command/control service.
 #                Ignored if IMEX_CMD_ENABLED=0


### PR DESCRIPTION
resolves https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/295

Because the `-i` param was removed in `nvidia-imex-ctl` after driver 580, we can no longer set it, which we did in https://github.com/NVIDIA/k8s-dra-driver-gpu/commit/53aba790fe6dd50811d310340fc0f4bfa6c60860, but this also un-fixed https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/328 with no obvious solution so ipv6 clusters no longer work.

So as a workaround, we now set `IMEX_CMD_BIND_INTERFACE_IP=127.0.0.1` in `/etc/nvidia-imex/config.cfg` which is [generated from a template](https://github.com/NVIDIA/k8s-dra-driver-gpu/blob/v25.3.0/templates/compute-domain-daemon-config.tmpl.cfg#L200) and is read by `nvidia-imex-ctl`.