### PR TITLE
fix: compute domain startup probe on ipv6 with driver 580+

### DIFF
--- a/templates/compute-domain-daemon-config.tmpl.cfg
+++ b/templates/compute-domain-daemon-config.tmpl.cfg
@@ -197,7 +197,7 @@ IMEX_CMD_ENABLED=1
 
 #  Description:  IP address to use to bind the command/control service.  Ignored if IMEX_CMD_ENABLED=0
 #                If empty, (but IMEX_CMD_PORT is specified), it will bind to all available interfaces.
-IMEX_CMD_BIND_INTERFACE_IP=
+IMEX_CMD_BIND_INTERFACE_IP=127.0.0.1
 
 #  Description:  Port to bind to (in conjunction with IMEX_CMD_BIND_INTERFACE) for the command/control service.
 #                Ignored if IMEX_CMD_ENABLED=0


### PR DESCRIPTION
Forward-port of https://github.com/NVIDIA/k8s-dra-driver-gpu/pull/510