### PR TITLE
Ensure we always have the *latest* ComputeDomain object when modifying

### DIFF
--- a/cmd/compute-domain-daemon/indexers.go
+++ b/cmd/compute-domain-daemon/indexers.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func uidIndexer[T metav1.ObjectMetaAccessor](obj any) ([]string, error) {
+	d, ok := obj.(T)
+	if !ok {
+		return nil, fmt.Errorf("expected a %T but got %T", *new(T), obj)
+	}
+	return []string{string(d.GetObjectMeta().GetUID())}, nil
+}


### PR DESCRIPTION
If we fail in the workqueue loop we could end up trying to modify a stale object forever if we don't resync it.