### PR TITLE
Add check to only remove computeDomain label matching specific UID

### DIFF
--- a/cmd/compute-domain-daemon/indexers.go
+++ b/cmd/compute-domain-daemon/indexers.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func uidIndexer[T metav1.ObjectMetaAccessor](obj any) ([]string, error) {
+	d, ok := obj.(T)
+	if !ok {
+		return nil, fmt.Errorf("expected a %T but got %T", *new(T), obj)
+	}
+	return []string{string(d.GetObjectMeta().GetUID())}, nil
+}

--- a/cmd/compute-domain-kubelet-plugin/computedomain.go
+++ b/cmd/compute-domain-kubelet-plugin/computedomain.go
@@ -308,6 +308,10 @@ func (m *ComputeDomainManager) RemoveNodeLabel(ctx context.Context, cdUID string
 		return nil
 	}
 
+	if node.Labels[computeDomainLabelKey] != cdUID {
+		return nil
+	}
+
 	newNode := node.DeepCopy()
 	delete(newNode.Labels, computeDomainLabelKey)
 


### PR DESCRIPTION
This was a bug and should always have been a condition being checked. Without this, we were seeing computeDomain labels "randomly" disappear from nodes when the cleanup loop to remove stale ComputeDomains kicked in. This would cause the computeDomain label from a *new* computeDomain to be removed even when only attempting to clean up a stale one.