### PR TITLE
Helm: Add an option to provide caBundle manually for webhook

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/templates/validatingwebhookconfiguration.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/validatingwebhookconfiguration.yaml
@@ -13,7 +13,7 @@ webhooks:
   - name: "gpu.nvidia.com"
     rules:
     - apiGroups:   ["resource.k8s.io"]
-      apiVersions: ["v1beta1"]
+      apiVersions: ["v1", "v1beta1", "v1beta2"]
       operations:  ["CREATE", "UPDATE"]
       resources:   ["resourceclaims", "resourceclaimtemplates"]
       scope:       "Namespaced"
@@ -23,6 +23,10 @@ webhooks:
         name: {{ include "nvidia-dra-driver-gpu.name" . }}-webhook
         port: {{ .Values.webhook.servicePort }}
         path: /validate-resource-claim-parameters
+      {{- if and (eq .Values.webhook.tls.mode "secret") .Values.webhook.tls.secret.caBundle }}
+      caBundle: {{ .Values.webhook.tls.secret.caBundle | quote }}
+      {{- end }}
+    failurePolicy: {{ default "Fail" .Values.webhook.failurePolicy | quote }}
     admissionReviewVersions: ["v1"]
     sideEffects: None
 {{- end }}

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/validatingwebhookconfiguration.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/validatingwebhookconfiguration.yaml
@@ -13,7 +13,7 @@ webhooks:
   - name: "gpu.nvidia.com"
     rules:
     - apiGroups:   ["resource.k8s.io"]
-      apiVersions: ["v1", "v1beta1", "v1beta2"]
+      apiVersions: ["v1beta1", "v1beta2", "v1"]
       operations:  ["CREATE", "UPDATE"]
       resources:   ["resourceclaims", "resourceclaimtemplates"]
       scope:       "Namespaced"

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/webhook-deployment.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/webhook-deployment.yaml
@@ -87,11 +87,6 @@ spec:
         secret:
           {{- if eq .Values.webhook.tls.mode "secret" }}
           secretName: {{ .Values.webhook.tls.secret.name }}
-          {{- if .Values.webhook.tls.secret.namespace }}
-          namespace: {{ .Values.webhook.tls.secret.namespace }}
-          {{- else }}
-          namespace: {{ include "nvidia-dra-driver-gpu.namespace" . }}
-          {{- end }}
           {{- else }}
           secretName: {{ include "nvidia-dra-driver-gpu.name" . }}-webhook-cert
           {{- end }}

--- a/deployments/helm/nvidia-dra-driver-gpu/values.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/values.yaml
@@ -114,10 +114,8 @@ webhook:
     secret:
       # Name of the secret containing tls.crt and tls.key
       name: ""
-      # Base64-encoded CA certificate bundle for validating the webhook's TLS certificate
-      # Required when using secret mode. You can either:
-      # 1. Provide the caBundle directly here (base64-encoded)
-      # 2. Include ca.crt in your secret (we will extract it during deployment)
+      # Base64-encoded CA certificate bundle for validating the webhook's TLS certificate (base64 encoded)
+      # Required when using secret mode.
       # Note: Only include intermediate CA certificates, not root CA certificates
       caBundle: ""
 

--- a/deployments/helm/nvidia-dra-driver-gpu/values.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/values.yaml
@@ -93,6 +93,11 @@ webhook:
     create: true
     # Annotations to add to the service account
     name: ""
+  # failurePolicy defines how the API server should handle requests if the webhook call fails.
+  # Options:
+  #   - Fail   : reject the request if the webhook call fails either due to cert errors, timeout or if the service is unreachable.
+  #   - Ignore : allow the request to continue if the webhook call fails.
+  failurePolicy: Fail
   # TLS certificate configuration
   tls:
     # Certificate management mode: "cert-manager" or "secret"
@@ -109,8 +114,12 @@ webhook:
     secret:
       # Name of the secret containing tls.crt and tls.key
       name: ""
-      # Namespace of the secret (if different from webhook namespace)
-      namespace: ""
+      # Base64-encoded CA certificate bundle for validating the webhook's TLS certificate
+      # Required when using secret mode. You can either:
+      # 1. Provide the caBundle directly here (base64-encoded)
+      # 2. Include ca.crt in your secret (we will extract it during deployment)
+      # Note: Only include intermediate CA certificates, not root CA certificates
+      caBundle: ""
 
 controller:
   priorityClassName: "system-node-critical"


### PR DESCRIPTION
This change introduces a new Helm chart value to supply a CA bundle (e.g., from `ca.crt`) directly into the ValidatingWebhookConfiguration when cert-manager is not used. This allows clusters without automated CA injection to configure the webhook manually and ensure proper TLS verification.

This also introduces a new option to ignore webhook failures and removes the invalid "namespace" parameter from the secret volume mount.