### PR TITLE
Conditionally set the apiVersion of all device classes we install

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/templates/_helpers.tpl
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/_helpers.tpl
@@ -169,3 +169,18 @@ Get all namespaces (driver namespace + additional namespaces from environment va
 {{- end }}
 {{- join "," $namespaces -}}
 {{- end -}}
+
+{{/*
+Get the latest available resource.k8s.io API version
+Returns the highest available version or empty string if none found
+*/}}
+{{- define "nvidia-dra-driver-gpu.resourceApiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "resource.k8s.io/v1" -}}
+resource.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "resource.k8s.io/v1beta1" -}}
+resource.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "resource.k8s.io/v1beta2" -}}
+resource.k8s.io/v1beta2
+{{- else -}}
+{{- end -}}
+{{- end -}}

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/deviceclass-compute-domain-daemon.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/deviceclass-compute-domain-daemon.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.resources.computeDomains.enabled }}
 ---
-apiVersion: resource.k8s.io/v1beta1
+apiVersion: {{ include "nvidia-dra-driver-gpu.resourceApiVersion" . }}
 kind: DeviceClass
 metadata:
   name: compute-domain-daemon.nvidia.com

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/deviceclass-compute-domain-default-channel.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/deviceclass-compute-domain-default-channel.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.resources.computeDomains.enabled }}
 ---
-apiVersion: resource.k8s.io/v1beta1
+apiVersion: {{ include "nvidia-dra-driver-gpu.resourceApiVersion" . }}
 kind: DeviceClass
 metadata:
   name: compute-domain-default-channel.nvidia.com

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/deviceclass-gpu.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/deviceclass-gpu.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.resources.gpus.enabled }}
 ---
-apiVersion: resource.k8s.io/v1beta1
+apiVersion: {{ include "nvidia-dra-driver-gpu.resourceApiVersion" . }}
 kind: DeviceClass
 metadata:
   name: gpu.nvidia.com

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/deviceclass-mig.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/deviceclass-mig.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.resources.gpus.enabled }}
 ---
-apiVersion: resource.k8s.io/v1beta1
+apiVersion: {{ include "nvidia-dra-driver-gpu.resourceApiVersion" . }}
 kind: DeviceClass
 metadata:
   name: mig.nvidia.com

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/validation.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/validation.yaml
@@ -117,3 +117,11 @@
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{- if not (include "nvidia-dra-driver-gpu.resourceApiVersion" .) -}}
+{{- $error := "" }}
+{{- $error = printf "%s\nNo supported resource.k8s.io API version found in the cluster." $error }}
+{{- $error = printf "%s\nThis chart requires one of: resource.k8s.io/v1, resource.k8s.io/v1beta1, or resource.k8s.io/v1beta2." $error }}
+{{- $error = printf "%s\nPlease ensure your cluster supports Dynamic Resource Allocation (DRA) with one of these API versions." $error }}
+{{- fail $error }}
+{{- end }}


### PR DESCRIPTION
This is done to ensure we only install DeviceClasses for the latest resource.k8s.io/<version> available in the cluster. This ensures we are backwards compatible for v1beta1, v1beta2, and v1 across k8s v1.32, v1.33, and v1.34+.

Fixes: https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/533