### PR TITLE
Ignore unknown fields when decoding opaque config JSON documents

### DIFF
--- a/api/nvidia.com/resource/v1beta1/api.go
+++ b/api/nvidia.com/resource/v1beta1/api.go
@@ -69,7 +69,14 @@ func init() {
 		scheme,
 		scheme,
 		json.SerializerOptions{
-			Pretty: true, Strict: true,
+			// Note: the strictness applies to all types defined above via
+			// AddKnownTypes(), i.e. it cannot be set per-type. That is OK in
+			// this case. Unknown fields will simply be dropped (ignored) upon
+			// decode, which is what we want. This is relevant in a downgrade
+			// case, when a checkpointed JSON document contains fields added in
+			// a later version (workload defined with a new version of this
+			// driver).
+			Pretty: true, Strict: false,
 		},
 	)
 }


### PR DESCRIPTION
This should resolve https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/578.

I asked Perplexity some questions. Answer quotes:

> when the Strict option is set to false, unknown fields in the JSON input are simply dropped (ignored) during decoding, and no error is raised for their presence. The decoder will only populate the struct with fields it recognizes, and any extra properties are not mapped or stored

> No per-type override: There is no built-in mechanism to change strictness for just a single type registered via AddKnownTypes or similar scheme-building methods


