### PR TITLE
Bump version to v25.3.3

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/Chart.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/Chart.yaml
@@ -19,13 +19,13 @@ description: Official Helm chart for the NVIDIA DRA Driver for GPUs
 type: application
 
 # Note(JP): strict semver: no v prefix allowed
-version: "25.3.2"
+version: "25.3.3"
 
 # Note(JP): templating logic consumes `appVersion` for building the default
 # `tag` value used in a k8s image specification. That logic expects the version
 # number below to not have a "v" prefix (a "v" is added by said logic to yield a
 # valid image reference).
-appVersion: "25.3.2"
+appVersion: "25.3.3"
 
 # The kubeVersion puts constraints on the Kubernetes versions where this helm
 # chart can be installed. Note a '-0' at the end of a version string in the

--- a/versions.mk
+++ b/versions.mk
@@ -18,7 +18,7 @@ MODULE := github.com/NVIDIA/$(DRIVER_NAME)
 
 REGISTRY ?= nvcr.io/nvidia
 
-VERSION  ?= v25.3.2
+VERSION  ?= v25.3.3
 
 # vVERSION represents the version with a guaranteed v-prefix
 # Note: this is probably not consumed in our build chain.


### PR DESCRIPTION
Incrementing the version towards the next release (as part of the [25.3.2](https://github.com/NVIDIA/k8s-dra-driver-gpu/releases/tag/v25.3.2) release process).