### PR TITLE
tests: dynamically inject DRA API version into spec

### DIFF
--- a/tests/bats/Makefile
+++ b/tests/bats/Makefile
@@ -49,7 +49,7 @@ TEST_NVIDIA_DRIVER_ROOT ?= "/run/nvidia/driver"
 TEST_EXPECTED_IMAGE_SPEC_SUBSTRING ?= $(VERSION)
 
 ifneq ($(TEST_CHART_LOCAL),"false")
-TEST_CHART_REPO = "deployments/helm/nvidia-dra-driver-gpu/"
+TEST_CHART_REPO = "deployments/helm/nvidia-dra-driver-gpu"
 TEST_CHART_VERSION = $(VERSION:v%=%)
 endif
 

--- a/tests/bats/setup_suite.bash
+++ b/tests/bats/setup_suite.bash
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+#  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Reference:
+# https://bats-core.readthedocs.io/en/latest/writing-tests.html#setup-and-teardown-pre-and-post-test-hooks
+
+# Validate that some prerequisites are met, and inspect environment for
+# characteristics, such as DRA API group version. A failing setup_suit()
+# function aborts the suite (fail fast).
+setup_suite () {
+    # Probe: kubectl configured against a k8s cluster.
+    kubectl cluster-info | grep "control plane is running at"
+
+    # Show, for debugging.
+    kubectl api-resources --api-group=resource.k8s.io
+
+    # Require DRA API group to be enabled (for now, maybe we want to add a test
+    # later that shows how Helm chart installation fails when DRA is not
+    # enabled, and then this suite-setup check could get in the way). The
+    # command below is expected to emit deviceclasses, resourceclaims,
+    # resourceclaimtemplates, resourceslices -- probe just one.
+    kubectl api-resources --api-group=resource.k8s.io | grep resourceslices
+
+    TEST_K8S_RESOURCE_API_VERSION=$( \
+        kubectl api-resources --api-group=resource.k8s.io -o json | \
+        jq -r '.resources | map(select(.version)) | .[0].version'
+    )
+
+    # Examples: v1, or v1beta1
+    export TEST_K8S_RESOURCE_API_VERSION
+}

--- a/tests/bats/specs/rc-opaque-cfg-unknown-field.yaml.tmpl
+++ b/tests/bats/specs/rc-opaque-cfg-unknown-field.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: resource.k8s.io/v1beta1
+apiVersion: resource.k8s.io/${TEST_K8S_RESOURCE_API_VERSION}
 kind: ResourceClaim
 metadata:
   name: batssuite-rc-bad-opaque-config

--- a/tests/bats/tests.bats
+++ b/tests/bats/tests.bats
@@ -164,7 +164,11 @@ apply_check_delete_workload_imex_chan_inject() {
 }
 
 @test "NodePrepareResources: catch unknown field in opaque cfg in ResourceClaim" {
-  local SPEC="tests/bats/specs/rc-opaque-cfg-unknown-field.yaml"
+  envsubst < tests/bats/specs/rc-opaque-cfg-unknown-field.yaml.tmpl > \
+    "${BATS_TEST_TMPDIR}"/rc-opaque-cfg-unknown-field.yaml
+  cd "${BATS_TEST_TMPDIR}"
+
+  local SPEC="rc-opaque-cfg-unknown-field.yaml"
 
   # Create pod with random name suffix.
   # Store ref of the form `pod/batssuite-pod-boc-brs2l`.


### PR DESCRIPTION
Resolves https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/621.

Setting a precedent for a bats [suite setup](https://bats-core.readthedocs.io/en/latest/writing-tests.html#setup-and-teardown-pre-and-post-test-hooks). Most important property here: fail-fast.

