### PR TITLE
Remove GPU index for CDI spec generation / attribute advertisement

### DIFF
--- a/cmd/gpu-kubelet-plugin/allocatable.go
+++ b/cmd/gpu-kubelet-plugin/allocatable.go
@@ -49,22 +49,22 @@ func (d *AllocatableDevice) CanonicalName() string {
 	panic("unexpected type for AllocatableDevice")
 }
 
-func (d *AllocatableDevice) CanonicalIndex() string {
-	switch d.Type() {
-	case GpuDeviceType:
-		return d.Gpu.CanonicalIndex()
-	case MigDeviceType:
-		return d.Mig.CanonicalIndex()
-	}
-	panic("unexpected type for AllocatableDevice")
-}
-
 func (d *AllocatableDevice) GetDevice() resourceapi.Device {
 	switch d.Type() {
 	case GpuDeviceType:
 		return d.Gpu.GetDevice()
 	case MigDeviceType:
 		return d.Mig.GetDevice()
+	}
+	panic("unexpected type for AllocatableDevice")
+}
+
+func (d AllocatableDevice) UUID() string {
+	if d.Gpu != nil {
+		return d.Gpu.UUID
+	}
+	if d.Mig != nil {
+		return d.Mig.UUID
 	}
 	panic("unexpected type for AllocatableDevice")
 }

--- a/cmd/gpu-kubelet-plugin/cdi.go
+++ b/cmd/gpu-kubelet-plugin/cdi.go
@@ -166,7 +166,7 @@ func (cdi *CDIHandler) CreateStandardDeviceSpecFile(allocatable AllocatableDevic
 	// Generate device specs for all full GPUs and MIG devices.
 	var deviceSpecs []cdispec.Device
 	for _, device := range allocatable {
-		dspecs, err := cdi.nvcdiDevice.GetDeviceSpecsByID(device.CanonicalIndex())
+		dspecs, err := cdi.nvcdiDevice.GetDeviceSpecsByID(device.UUID())
 		if err != nil {
 			return fmt.Errorf("unable to get device spec for %s: %w", device.CanonicalName(), err)
 		}

--- a/cmd/gpu-kubelet-plugin/deviceinfo.go
+++ b/cmd/gpu-kubelet-plugin/deviceinfo.go
@@ -30,7 +30,6 @@ import (
 
 type GpuInfo struct {
 	UUID                  string `json:"uuid"`
-	index                 int
 	minor                 int
 	migEnabled            bool
 	memoryBytes           uint64
@@ -47,7 +46,6 @@ type GpuInfo struct {
 
 type MigDeviceInfo struct {
 	UUID          string `json:"uuid"`
-	index         int
 	profile       string
 	parent        *GpuInfo
 	placement     *MigDevicePlacement
@@ -80,14 +78,6 @@ func (d *MigDeviceInfo) CanonicalName() string {
 	return fmt.Sprintf("gpu-%d-mig-%d-%d-%d", d.parent.minor, d.giInfo.ProfileId, d.placement.Start, d.placement.Size)
 }
 
-func (d *GpuInfo) CanonicalIndex() string {
-	return fmt.Sprintf("%d", d.index)
-}
-
-func (d *MigDeviceInfo) CanonicalIndex() string {
-	return fmt.Sprintf("%d:%d", d.parent.index, d.index)
-}
-
 func (d *GpuInfo) GetDevice() resourceapi.Device {
 	device := resourceapi.Device{
 		Name: d.CanonicalName(),
@@ -100,9 +90,6 @@ func (d *GpuInfo) GetDevice() resourceapi.Device {
 			},
 			"minor": {
 				IntValue: ptr.To(int64(d.minor)),
-			},
-			"index": {
-				IntValue: ptr.To(int64(d.index)),
 			},
 			"productName": {
 				StringValue: &d.productName,
@@ -150,12 +137,6 @@ func (d *MigDeviceInfo) GetDevice() resourceapi.Device {
 			},
 			"parentUUID": {
 				StringValue: &d.parent.UUID,
-			},
-			"index": {
-				IntValue: ptr.To(int64(d.index)),
-			},
-			"parentIndex": {
-				IntValue: ptr.To(int64(d.parent.index)),
 			},
 			"profile": {
 				StringValue: &d.profile,

--- a/cmd/gpu-kubelet-plugin/deviceinfo.go
+++ b/cmd/gpu-kubelet-plugin/deviceinfo.go
@@ -88,9 +88,6 @@ func (d *GpuInfo) GetDevice() resourceapi.Device {
 			"uuid": {
 				StringValue: &d.UUID,
 			},
-			"minor": {
-				IntValue: ptr.To(int64(d.minor)),
-			},
 			"productName": {
 				StringValue: &d.productName,
 			},

--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -264,7 +264,6 @@ func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) 
 	gpuInfo := &GpuInfo{
 		UUID:                  uuid,
 		minor:                 minor,
-		index:                 index,
 		migEnabled:            migEnabled,
 		memoryBytes:           memory.Total,
 		productName:           productName,
@@ -360,7 +359,6 @@ func (l deviceLib) getMigDevices(gpuInfo *GpuInfo) (map[string]*MigDeviceInfo, e
 
 		migInfos[uuid] = &MigDeviceInfo{
 			UUID:          uuid,
-			index:         i,
 			profile:       migProfile.String(),
 			parent:        gpuInfo,
 			placement:     &placement,

--- a/cmd/gpu-kubelet-plugin/prepared.go
+++ b/cmd/gpu-kubelet-plugin/prepared.go
@@ -65,16 +65,6 @@ func (d *PreparedDevice) CanonicalName() string {
 	panic("unexpected type for AllocatableDevice")
 }
 
-func (d *PreparedDevice) CanonicalIndex() string {
-	switch d.Type() {
-	case GpuDeviceType:
-		return d.Gpu.Info.CanonicalIndex()
-	case MigDeviceType:
-		return d.Mig.Info.CanonicalIndex()
-	}
-	panic("unexpected type for AllocatableDevice")
-}
-
 func (l PreparedDeviceList) Gpus() PreparedDeviceList {
 	var devices PreparedDeviceList
 	for _, device := range l {


### PR DESCRIPTION
Fixes: #563 

Tested with:
* https://github.com/NVIDIA/k8s-dra-driver-gpu/blob/b3325005002081a4998531302cdf24b1a711b29c/demo/specs/quickstart/gpu-test1.yaml
* https://github.com/NVIDIA/k8s-dra-driver-gpu/blob/b3325005002081a4998531302cdf24b1a711b29c/demo/specs/quickstart/gpu-test2.yaml
* https://github.com/NVIDIA/k8s-dra-driver-gpu/blob/b3325005002081a4998531302cdf24b1a711b29c/demo/specs/quickstart/gpu-test3.yaml
* https://github.com/NVIDIA/k8s-dra-driver-gpu/blob/b3325005002081a4998531302cdf24b1a711b29c/demo/specs/quickstart/gpu-test4.yaml