### PR TITLE
CD plugin: log detail around fabric cliqueID readout

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -94,6 +94,8 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 		return nil, fmt.Errorf("unable to create CDI handler: %w", err)
 	}
 
+	// TODO: explore calling this not only during plugin startup because this
+	// information may change during runtime.
 	cliqueID, err := nvdevlib.getCliqueID()
 	if err != nil {
 		return nil, fmt.Errorf("error getting cliqueID: %w", err)

--- a/cmd/compute-domain-kubelet-plugin/nvlib.go
+++ b/cmd/compute-domain-kubelet-plugin/nvlib.go
@@ -206,28 +206,41 @@ func (l deviceLib) getCliqueID() (string, error) {
 	uniqueCliqueIDs := make(map[string]struct{})
 
 	err := l.VisitDevices(func(i int, d nvdev.Device) error {
+		duid, ret := d.GetUUID()
+		if ret != nvml.SUCCESS {
+			return fmt.Errorf("failed to read device uuid (%d): %w", i, ret)
+		}
+
 		isFabricAttached, err := d.IsFabricAttached()
 		if err != nil {
-			return fmt.Errorf("error checking if device is fabric attached: %w", err)
+			return fmt.Errorf("error checking if fabric is attached (device %d/%s): %w", i, duid, err)
 		}
+
 		if !isFabricAttached {
+			klog.Infof("no-clique fallback: fabric not attached (device %d/%s)", i, duid)
 			return nil
 		}
 
+		// TODO: explore using GetGpuFabricInfoV() which can return
+		// nvmlGpuFabricInfo_v3_t which contains `state`, `status`, and
+		// `healthSummary`. The latter we may at least want to log (may be
+		// "unhealthy"). See
+		// https://docs.nvidia.com/deploy/nvml-api/group__nvmlFabricDefs.html
 		info, ret := d.GetGpuFabricInfo()
 		if ret != nvml.SUCCESS {
-			return fmt.Errorf("failed to get GPU fabric info: %w", ret)
+			return fmt.Errorf("failed to get GPU fabric info (device %d/%s): %w", i, duid, ret)
 		}
 
 		clusterUUID, err := uuid.FromBytes(info.ClusterUuid[:])
 		if err != nil {
-			return fmt.Errorf("invalid cluster UUID: %w", err)
+			return fmt.Errorf("invalid cluster UUID (device %d/%s): %w", i, duid, err)
 		}
 
 		cliqueID := fmt.Sprintf("%d", info.CliqueId)
 
 		uniqueClusterUUIDs[clusterUUID.String()] = struct{}{}
 		uniqueCliqueIDs[cliqueID] = struct{}{}
+		klog.Infof("identified fabric clique UUID/ID (device %d/%s): %s/%s", i, duid, clusterUUID.String(), cliqueID)
 
 		return nil
 	})


### PR DESCRIPTION
As of https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/626, we observed that the no-clique fallback code path may be visited upon unhealthy fabric state with `isFabricAttached` being `false` (leading to the CD daemon starting up in noop mode).

This may not be the ideal behavior in the long run.

For now, this patch adds relevant detail to the plugin's log output so that one can quickly understand _why_ no clique ID was passed into the CD daemon.

I've scattered in a few more log messages around reading out the various IDs. The readout is triggered during kubelet plugin startup only, and hence that's not too noisy (but potentially valuable signal for debugging).

I've also added a note about us probably wanting to figure out how to make the CD plugin react to fabric configuration/state changes during runtime (further down the line, we may want to support a clique ID update; but that requires careful design).

Happy path log output:
```
$ kubectl logs -n nvidia-dra-driver-gpu   nvidia-dra-driver-gpu-kubelet-plugin-l7xvz
...
I0929 12:40:26.277236       1 nvlib.go:243] identified fabric clique UUID/ID (device 0/GPU-6328b923-c487-281a-fd27-291f5d278893): 6a130f54-faaa-4b8f-847f-be44ab70f917/32766
I0929 12:40:26.283393       1 nvlib.go:243] identified fabric clique UUID/ID (device 1/GPU-c3e161bb-cfc0-066a-e6c1-0bce39732ff6): 6a130f54-faaa-4b8f-847f-be44ab70f917/32766
I0929 12:40:26.289527       1 nvlib.go:243] identified fabric clique UUID/ID (device 2/GPU-09ceef72-e6f2-1135-5343-419da5413ed0): 6a130f54-faaa-4b8f-847f-be44ab70f917/32766
I0929 12:40:26.295648       1 nvlib.go:243] identified fabric clique UUID/ID (device 3/GPU-7d7868da-6d45-2e46-54fb-b5c702b7f62b): 6a130f54-faaa-4b8f-847f-be44ab70f917/32766
...
```