### PR TITLE
tests: fixes, improved cleanup & stability, better debuggability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 [._]*.sw[a-p]
 coverage.out
 tests-out
+*.log
+*.tar
+*.tgz
+

--- a/tests/bats/Makefile
+++ b/tests/bats/Makefile
@@ -56,6 +56,13 @@ endif
 BATS_IMAGE = batstests:$(GIT_COMMIT_SHORT)
 KUBECONFIG ?= $(HOME)/.kube/config
 
+# Add `docker run` arguments when not running
+# in Github Actions / GitLab CI.
+DOCKER_RUN_FLAGS :=
+ifeq ($(CI),)
+  DOCKER_RUN_FLAGS += -it
+endif
+
 default: tests
 
 .PHONY: image
@@ -71,9 +78,10 @@ image:
 .PHONY: tests
 tests: image
 	mkdir -p tests-out && \
-	export _RUNDIR=$(shell mktemp -p tests-out -d -t bats-tests-$$(date +%s)-XXXXX) && \
-	time docker run \
-		-it \
+	export _RUNDIR=$$(mktemp -p tests-out -d -t bats-tests-$$(date +%s)-XXXXX) && \
+	docker run \
+		--rm \
+		$(DOCKER_RUN_FLAGS) \
 		-v /tmp:/tmp \
 		-v $(CURDIR):/cwd \
 		-v $(HOME)/.kube/:$(HOME)/.kube \
@@ -88,7 +96,7 @@ tests: image
 		-u $(shell id -u ${USER}):$(shell id -g ${USER}) \
 		--entrypoint "/bin/bash"\
 		$(BATS_IMAGE) \
-		-c "cd /cwd; \
+		-c "set -ex; cd /cwd; \
 			echo 'Running k8s cluster cleanup (invasive)... '; \
 			bash tests/bats/cleanup-from-previous-run.sh 2>&1 | tee -a $${_RUNDIR}/cleanup.outerr; \
 			TMPDIR=/cwd/$${_RUNDIR} bats \

--- a/tests/bats/helpers.sh
+++ b/tests/bats/helpers.sh
@@ -19,6 +19,14 @@
 # Helm chart release was installed/managed by this test suite.
 export TEST_HELM_RELEASE_NAME="nvidia-dra-driver-gpu-batssuite"
 
+
+_common_setup() {
+  load '/bats-libraries/bats-support/load.bash'
+  load '/bats-libraries/bats-assert/load.bash'
+  load '/bats-libraries/bats-file/load.bash'
+}
+
+
 # A helper arg for `iupgrade_wait` w/o additional install args.
 export NOARGS=()
 

--- a/tests/bats/setup_suite.bash
+++ b/tests/bats/setup_suite.bash
@@ -25,6 +25,11 @@ setup_suite () {
     # Probe: kubectl configured against a k8s cluster.
     kubectl cluster-info | grep "control plane is running at"
 
+    # Fail fast in case there seems to be a DRA driver Helm chart installed at
+    # this point (maybe one _not_ managed by this test suite).
+    helm list -A
+    helm list -A | grep "nvidia-dra-driver-gpu" && { echo "error: helm list not clean"; return 1; }
+
     # Show, for debugging.
     kubectl api-resources --api-group=resource.k8s.io
 

--- a/tests/bats/tests.bats
+++ b/tests/bats/tests.bats
@@ -76,7 +76,7 @@ iupgrade_wait() {
 
 apply_check_delete_workload_imex_chan_inject() {
   kubectl apply -f demo/specs/imex/channel-injection.yaml
-  kubectl wait --for=condition=READY pods imex-channel-injection --timeout=70s
+  kubectl wait --for=condition=READY pods imex-channel-injection --timeout=100s
   run kubectl logs imex-channel-injection
   assert_output --partial "channel0"
   kubectl delete -f demo/specs/imex/channel-injection.yaml

--- a/tests/bats/tests.bats
+++ b/tests/bats/tests.bats
@@ -1,10 +1,9 @@
 # shellcheck disable=SC2148
 # shellcheck disable=SC2329
 setup() {
-  load '/bats-libraries/bats-support/load.bash'
-  load '/bats-libraries/bats-assert/load.bash'
-  load '/bats-libraries/bats-file/load.bash'
-  load 'helpers.sh'
+  # Executed before entering each test in this file.
+   load 'helpers.sh'
+  _common_setup
 }
 
 # Currently, the tests defined in this file deliberately depend on each other

--- a/tests/bats/tests.bats
+++ b/tests/bats/tests.bats
@@ -242,7 +242,7 @@ log_objects() {
   log_objects
 
   # Stage 1: clean slate
-  helm uninstall "${TEST_HELM_RELEASE_NAME}" -n nvidia-dra-driver-gpu
+  helm uninstall "${TEST_HELM_RELEASE_NAME}" -n nvidia-dra-driver-gpu --wait --timeout=30s
   kubectl wait --for=delete pods -A -l app.kubernetes.io/name=nvidia-dra-driver-gpu --timeout=10s
   bash tests/bats/clean-state-dirs-all-nodes.sh
   kubectl get crd computedomains.resource.nvidia.com

--- a/tests/bats/tests.bats
+++ b/tests/bats/tests.bats
@@ -79,8 +79,7 @@ log_objects() {
 }
 
 @test "helm-install ${TEST_CHART_REPO}/${TEST_CHART_VERSION}" {
-  local _iargs=("--set" "featureGates.IMEXDaemonsWithDNSNames=true")
-  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" NOARGS
 }
 
 @test "helm list: validate output" {
@@ -262,8 +261,7 @@ log_objects() {
   kubectl apply -f "${CRD_UPGRADE_URL}"
 
   # Stage 5: install target version (as users would do).
-  local _iargs=("--set" "featureGates.IMEXDaemonsWithDNSNames=true")
-  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" NOARGS
 
   # Stage 6: confirm deleting old workload works (critical, see above).
   timeout -v 60 kubectl delete -f demo/specs/imex/channel-injection.yaml

--- a/tests/bats/tests.bats
+++ b/tests/bats/tests.bats
@@ -15,10 +15,6 @@ setup() {
 # happening. Tools like `etcdctl` will be helpful.
 
 
-# Use a name that upon cluster inspection reveals that this
-# Helm chart release was installed/managed by this test suite.
-export TEST_HELM_RELEASE_NAME="nvidia-dra-driver-gpu-batssuite"
-
 # Note(JP): bats swallows output of setup upon success (regardless of cmdline
 # args such as `--show-output-of-passing-tests`). Ref:
 # https://github.com/bats-core/bats-core/issues/540#issuecomment-1013521656 --
@@ -41,38 +37,8 @@ setup_file() {
   # Prepare for installing releases from NGC (that merely mutates local
   # filesystem state).
   helm repo add nvidia https://helm.ngc.nvidia.com/nvidia && helm repo update
-
-  # A helper arg for `iupgrade_wait` w/o additional install args.
-  export NOARGS=()
 }
 
-# Install or upgrade, and wait for pods to be READY.
-# 1st arg: helm chart repo
-# 2nd arg: helm chart version
-# 3rd arg: array with additional args (provide `NOARGS` if none)
-iupgrade_wait() {
-  # E.g. `nvidia/nvidia-dra-driver-gpu` or
-  # `oci://ghcr.io/nvidia/k8s-dra-driver-gpu`
-  local REPO="$1"
-
-  # E.g. `25.3.1` or `25.8.0-dev-f2eaddd6-chart`
-  local VERSION="$2"
-
-  # Expect array as third argument.
-  local -n ADDITIONAL_INSTALL_ARGS=$3
-
-  timeout -v 10 helm upgrade --install "${TEST_HELM_RELEASE_NAME}" \
-    "${REPO}" \
-    --version="${VERSION}" \
-    --create-namespace \
-    --namespace nvidia-dra-driver-gpu \
-    --set resources.gpus.enabled=false \
-    --set nvidiaDriverRoot="${TEST_NVIDIA_DRIVER_ROOT}" "${ADDITIONAL_INSTALL_ARGS[@]}"
-
-  kubectl wait --for=condition=READY pods -A -l nvidia-dra-driver-gpu-component=kubelet-plugin --timeout=10s
-  kubectl wait --for=condition=READY pods -A -l nvidia-dra-driver-gpu-component=controller --timeout=10s
-  # maybe: check version on labels (to confirm that we set labels correctly)
-}
 
 apply_check_delete_workload_imex_chan_inject() {
   kubectl apply -f demo/specs/imex/channel-injection.yaml

--- a/tests/bats/tests.bats
+++ b/tests/bats/tests.bats
@@ -39,13 +39,18 @@ setup_file() {
   helm repo add nvidia https://helm.ngc.nvidia.com/nvidia && helm repo update
 }
 
-
 apply_check_delete_workload_imex_chan_inject() {
   kubectl apply -f demo/specs/imex/channel-injection.yaml
   kubectl wait --for=condition=READY pods imex-channel-injection --timeout=100s
   run kubectl logs imex-channel-injection
-  assert_output --partial "channel0"
   kubectl delete -f demo/specs/imex/channel-injection.yaml
+  # Check output after attempted deletion.
+  assert_output --partial "channel0"
+
+  # Wait for deletion to complete; this is critical before moving on to the next
+  # test (as long as we don't wipe state entirely between tests).
+  kubectl wait --for=delete pods imex-channel-injection --timeout=10s
+}
 
 log_objects() {
   # Never fail, but show output in case a test fails, to facilitate debugging.


### PR DESCRIPTION
Initiative: https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/613.

This branch is a collection of test suite-related patches that I've accumulated over the past days in various branches.

For example:

- Fixed an order-of-execution bug in the main makefile target (this time for real)
- Various test stability fixes (around workload teardown, and Helm chart upgrade in particular)
- Remove dependency on `time`, dynamically use `-it`, add `--rm` (towards CI in GHA)
- More brute-force in cleanup
- More fail-fast criteria
- Timeout constant tweaks based on observation, to support tail end scenarios (stability improvements)
- Better debuggability (more log output emitted in case things go wrong)

For details, see individual commits.