### PR TITLE
Logging improvements for debuggability (CD daemon, plugin)

### DIFF
--- a/cmd/compute-domain-daemon/main.go
+++ b/cmd/compute-domain-daemon/main.go
@@ -244,6 +244,7 @@ func run(ctx context.Context, cancel context.CancelFunc, flags *Flags) error {
 			klog.Errorf("controller failed, initiate shutdown: %s", err)
 			cancel()
 		}
+		klog.Infof("Terminated: controller task")
 	}()
 
 	// Start IMEX daemon update loop in goroutine (watches for CD status
@@ -264,6 +265,7 @@ func run(ctx context.Context, cancel context.CancelFunc, flags *Flags) error {
 				cancel()
 			}
 		}
+		klog.Infof("Terminated: IMEX daemon update task")
 	}()
 
 	// Start child process watchdog in goroutine.
@@ -276,11 +278,13 @@ func run(ctx context.Context, cancel context.CancelFunc, flags *Flags) error {
 			klog.Errorf("watch failed, initiate shutdown: %s", err)
 			cancel()
 		}
+		klog.Infof("Terminated: process manager")
 	}()
 
 	wg.Wait()
 
 	// Let's not yet try to make exit code promises.
+	klog.Infof("Exiting")
 	return nil
 }
 

--- a/cmd/compute-domain-kubelet-plugin/driver.go
+++ b/cmd/compute-domain-kubelet-plugin/driver.go
@@ -245,7 +245,7 @@ func (d *driver) nodePrepareResource(ctx context.Context, claim *resourceapi.Res
 	devs, err := d.state.Prepare(ctx, claim)
 	if err != nil {
 		res := kubeletplugin.PrepareResult{
-			Err: fmt.Errorf("error preparing devices for claim %v: %w", claim.UID, err),
+			Err: fmt.Errorf("error preparing devices for claim %s/%s:%s: %w", claim.Namespace, claim.Name, claim.UID, err),
 		}
 		if isPermanentError(err) {
 			klog.V(6).Infof("Permanent error preparing devices for claim %v: %v", claim.UID, err)
@@ -254,7 +254,7 @@ func (d *driver) nodePrepareResource(ctx context.Context, claim *resourceapi.Res
 		return false, res
 	}
 
-	klog.Infof("Returning newly prepared devices for claim '%v': %v", claim.UID, devs)
+	klog.Infof("prepared devices for claim '%s/%s:%s': %v", claim.Namespace, claim.Name, claim.UID, devs)
 	return true, kubeletplugin.PrepareResult{Devices: devs}
 }
 


### PR DESCRIPTION
Small-ish but valuable log message improvements that I desired while investigating things over the last few days.

1) Explicit progress report on regular shutdown of the CD daemon 
2) Log claim name + namespace on prep for debuggability

About (1): occasionally, I wondered if the global wait group's `wg.Wait()` actually did return, and if it didn't -- which of the tasks in it would not have finished yet.

About (2): that standard format is for example already used in unprepare:

>  unprepared devices for claim 'default/nvbandwidth-test-2-worker-0-compute-domain-channel-mnkrw:67417068-92da-4bbd-803c-ddcbbf0f067f'

In prepare, we so far only log by claim UID:

> prepared devices for claim '67417068-92da-4bbd-803c-ddcbbf0f067f': ...

That makes things harder to debug (grepping plugin logs for the claim name should work).

