### PR TITLE
CD daemon: coordinate CD updates on shutdown via mutation cache

### DIFF
--- a/cmd/compute-domain-daemon/computedomain.go
+++ b/cmd/compute-domain-daemon/computedomain.go
@@ -78,7 +78,6 @@ func NewComputeDomainManager(config *ManagerConfig) *ComputeDomainManager {
 		previousNodes:    []*nvapi.ComputeDomainNode{},
 		updatedNodesChan: make(chan []*nvapi.ComputeDomainNode),
 	}
-	m.podManager = NewPodManager(config, m.Get)
 
 	return m
 }
@@ -111,6 +110,8 @@ func (m *ComputeDomainManager) Start(ctx context.Context) (rerr error) {
 		mutationCacheTTL,
 		true,
 	)
+
+	m.podManager = NewPodManager(m.config, m.Get, &m.mutationCache)
 
 	_, err = m.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {

--- a/cmd/compute-domain-daemon/computedomain.go
+++ b/cmd/compute-domain-daemon/computedomain.go
@@ -392,12 +392,12 @@ func (m *ComputeDomainManager) removeNodeFromComputeDomain(ctx context.Context) 
 		newCD.Status.Status = nvapi.ComputeDomainStatusNotReady
 	}
 
+	// Update status and (upon success) store the latest version of the object
+	// (as returned by the API server) in the mutation cache.
 	newCD.Status.Nodes = updatedNodes
 	if _, err := m.config.clientsets.Nvidia.ResourceV1beta1().ComputeDomains(newCD.Namespace).UpdateStatus(ctx, newCD, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("error removing node from ComputeDomain status: %w", err)
 	}
-
-	// Add the updated ComputeDomain to the mutation cache
 	m.mutationCache.Mutation(newCD)
 
 	klog.Infof("Successfully removed node with IP %s from ComputeDomain %s/%s", m.config.podIP, newCD.Namespace, newCD.Name)

--- a/cmd/compute-domain-daemon/podmanager.go
+++ b/cmd/compute-domain-daemon/podmanager.go
@@ -39,10 +39,11 @@ type PodManager struct {
 	cancelContext    context.CancelFunc
 	podInformer      cache.SharedIndexInformer
 	informerFactory  informers.SharedInformerFactory
+	mutationCache    cache.MutationCache
 }
 
 // NewPodManager creates a new PodManager instance.
-func NewPodManager(config *ManagerConfig, getComputeDomain GetComputeDomainFunc) *PodManager {
+func NewPodManager(config *ManagerConfig, getComputeDomain GetComputeDomainFunc, mutationCache *cache.MutationCache) *PodManager {
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(
 		config.clientsets.Core,
 		informerResyncPeriod,
@@ -59,6 +60,7 @@ func NewPodManager(config *ManagerConfig, getComputeDomain GetComputeDomainFunc)
 		getComputeDomain: getComputeDomain,
 		podInformer:      podInformer,
 		informerFactory:  informerFactory,
+		mutationCache:    *mutationCache,
 	}
 
 	return p
@@ -192,5 +194,7 @@ func (pm *PodManager) updateNodeStatus(ctx context.Context, status string) error
 	}
 
 	klog.Infof("Successfully updated node %s status to %s", pm.config.nodeName, status)
+
+	pm.mutationCache.Mutation(newCD)
 	return nil
 }


### PR DESCRIPTION
This is for #649.

On shutdown, we perform two mutations on the CD object, in fast succession: 

1. `podManager` sets node status to `NotReady` because the state pod transitions away from `Ready` (because it is not `Running` anymore, but `Terminating` -- or because probes start to fail).
2. `computeDomainManager` removes the node status.

This patch makes sure that these two mutations build on top of each other, coordinated through the mutation cache and by putting the latest CD object into that cache (as returned by the API server) before attempting the second mutation.

I first tested this manually, and then translated the test into one for our bats suite (also added to this PR).

