### PR TITLE
Introduce DefaultPrepUnprepRateLimiter (less aggressive)

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/driver.go
+++ b/cmd/compute-domain-kubelet-plugin/driver.go
@@ -157,7 +157,7 @@ func (d *driver) PrepareResourceClaims(ctx context.Context, claims []*resourceap
 
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithTimeout(ctx, ErrorRetryMaxTimeout)
-	workQueue := workqueue.New(workqueue.DefaultControllerRateLimiter())
+	workQueue := workqueue.New(workqueue.DefaultPrepUnprepRateLimiter())
 	results := make(map[types.UID]kubeletplugin.PrepareResult)
 
 	for _, claim := range claims {
@@ -188,7 +188,10 @@ func (d *driver) UnprepareResourceClaims(ctx context.Context, claimRefs []kubele
 
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithTimeout(ctx, ErrorRetryMaxTimeout)
-	workQueue := workqueue.New(workqueue.DefaultControllerRateLimiter())
+
+	// Review: do we want to have a new queue per incoming Prepare/Unprepare
+	// request?
+	workQueue := workqueue.New(workqueue.DefaultPrepUnprepRateLimiter())
 	results := make(map[types.UID]error)
 
 	for _, claim := range claimRefs {


### PR DESCRIPTION
https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/655

This PR provides a starting point. So that we can start choosing our own parameters, in a context-specific way.

Retrying behavior change at the core -- with this patch, we use
```
ExponentialFailureRateLimiter[any](250*time.Millisecond, 3000*time.Second)
```
instead of 
```
ExponentialFailureRateLimiter[T](5*time.Millisecond, 1000*time.Second)
```
Here, I mainly cared about bumping the lower bound by orders of magnitude. I didn't want to bump the upper bound by factor 10 here to not provoke controversial discussion.

If in the future we ever find the work queue rate limiter to introduce problems (still being too fast, or introducing unnecessary latency  -- measured as part of latency/performance tuning): let's of course adjust the parameters.